### PR TITLE
Implement US-002 forced first-login password reset

### DIFF
--- a/backend/apps/users/api/permissions.py
+++ b/backend/apps/users/api/permissions.py
@@ -1,0 +1,16 @@
+from rest_framework.permissions import BasePermission
+
+
+class IsAuthenticatedAndPasswordResetComplete(BasePermission):
+    message = "Password reset required."
+
+    def has_permission(self, request, view) -> bool:
+        user = request.user
+
+        if not user or not user.is_authenticated:
+            return False
+
+        if not user.is_active or user.deleted_at is not None:
+            return False
+
+        return not user.must_reset_password

--- a/backend/apps/users/api/serializers.py
+++ b/backend/apps/users/api/serializers.py
@@ -6,6 +6,10 @@ class LoginSerializer(serializers.Serializer):
     password = serializers.CharField(trim_whitespace=False)
 
 
+class ForceResetPasswordSerializer(serializers.Serializer):
+    new_password = serializers.CharField(trim_whitespace=False)
+
+
 class SessionUserSerializer(serializers.Serializer):
     id = serializers.UUIDField(format="hex_verbose")
     email = serializers.EmailField()

--- a/backend/apps/users/api/urls.py
+++ b/backend/apps/users/api/urls.py
@@ -1,8 +1,13 @@
 from django.urls import path
 
-from .views import CurrentUserView, LoginView
+from .views import CurrentUserView, ForceResetPasswordView, LoginView
 
 urlpatterns = [
     path("auth/login", LoginView.as_view(), name="auth-login"),
     path("auth/me", CurrentUserView.as_view(), name="auth-me"),
+    path(
+        "auth/force-reset-password",
+        ForceResetPasswordView.as_view(),
+        name="auth-force-reset-password",
+    ),
 ]

--- a/backend/apps/users/api/views.py
+++ b/backend/apps/users/api/views.py
@@ -8,11 +8,18 @@ from rest_framework.views import APIView
 from apps.users.domain.services import (
     InvalidCredentialsError,
     authenticate_user_session,
+    force_reset_password,
     get_active_session_user,
+    PasswordResetNotRequiredError,
+    PasswordValidationFailedError,
     serialize_session_user,
 )
 
-from .serializers import LoginSerializer, SessionUserSerializer
+from .serializers import (
+    ForceResetPasswordSerializer,
+    LoginSerializer,
+    SessionUserSerializer,
+)
 
 
 def error_response(*, code: str, message: str, details: dict, status_code: int) -> Response:
@@ -83,3 +90,65 @@ class CurrentUserView(APIView):
 
         serializer = SessionUserSerializer(serialize_session_user(session_user))
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+@method_decorator(csrf_protect, name="dispatch")
+class ForceResetPasswordView(APIView):
+    permission_classes = [permissions.AllowAny]
+
+    def post(self, request):
+        session_user = get_active_session_user(request)
+        if session_user is None:
+            return error_response(
+                code="UNAUTHENTICATED",
+                message="Authentication required.",
+                details={},
+                status_code=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        serializer = ForceResetPasswordSerializer(data=request.data)
+        if not serializer.is_valid():
+            return error_response(
+                code="VALIDATION_ERROR",
+                message="Invalid input",
+                details=serializer.errors,
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            updated_user = force_reset_password(
+                request=request,
+                user=session_user,
+                new_password=serializer.validated_data["new_password"],
+            )
+        except PasswordValidationFailedError as exc:
+            return error_response(
+                code="VALIDATION_ERROR",
+                message="Invalid input",
+                details=exc.details,
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+        except PasswordResetNotRequiredError:
+            return error_response(
+                code="PASSWORD_RESET_NOT_REQUIRED",
+                message="Password reset is not required for this user.",
+                details={},
+                status_code=status.HTTP_403_FORBIDDEN,
+            )
+
+        if updated_user is None:
+            return error_response(
+                code="UNAUTHENTICATED",
+                message="Authentication required.",
+                details={},
+                status_code=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        user_data = SessionUserSerializer(serialize_session_user(updated_user)).data
+        return Response(
+            {
+                "user": user_data,
+                "requires_password_reset": False,
+            },
+            status=status.HTTP_200_OK,
+        )

--- a/backend/apps/users/domain/services.py
+++ b/backend/apps/users/domain/services.py
@@ -3,7 +3,17 @@ from dataclasses import dataclass
 from django.conf import settings
 from django.contrib.auth import login as django_login
 from django.contrib.auth import logout as django_logout
+from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth import get_user_model
+from django.contrib.auth.password_validation import (
+    CommonPasswordValidator,
+    MinimumLengthValidator,
+    NumericPasswordValidator,
+    UserAttributeSimilarityValidator,
+    password_changed,
+    validate_password,
+)
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.utils import timezone
 
@@ -12,10 +22,28 @@ class InvalidCredentialsError(Exception):
     pass
 
 
+class PasswordResetNotRequiredError(Exception):
+    pass
+
+
+class PasswordValidationFailedError(Exception):
+    def __init__(self, details: dict[str, list[str]]):
+        super().__init__("Password validation failed.")
+        self.details = details
+
+
 @dataclass(frozen=True)
 class AuthenticatedSession:
     user: object
     requires_password_reset: bool
+
+
+DEFAULT_PASSWORD_VALIDATORS = [
+    UserAttributeSimilarityValidator(),
+    MinimumLengthValidator(),
+    CommonPasswordValidator(),
+    NumericPasswordValidator(),
+]
 
 
 def serialize_session_user(user) -> dict[str, str | bool]:
@@ -38,6 +66,42 @@ def get_active_session_user(request):
         return None
 
     return user
+
+
+def validate_user_password(*, user, password: str) -> None:
+    try:
+        if getattr(settings, "AUTH_PASSWORD_VALIDATORS", None):
+            validate_password(password, user=user)
+        else:
+            validate_password(
+                password,
+                user=user,
+                password_validators=DEFAULT_PASSWORD_VALIDATORS,
+            )
+    except ValidationError as exc:
+        raise PasswordValidationFailedError({"new_password": exc.messages}) from exc
+
+
+@transaction.atomic
+def force_reset_password(*, request, user, new_password: str):
+    locked_user = user.__class__.all_objects.select_for_update().get(pk=user.pk)
+
+    if locked_user.deleted_at is not None or not locked_user.is_active:
+        django_logout(request)
+        return None
+
+    if not locked_user.must_reset_password:
+        raise PasswordResetNotRequiredError
+
+    validate_user_password(user=locked_user, password=new_password)
+
+    locked_user.set_password(new_password)
+    locked_user.must_reset_password = False
+    locked_user.save(update_fields=["password", "must_reset_password", "updated_at"])
+    password_changed(new_password, locked_user)
+    update_session_auth_hash(request, locked_user)
+
+    return locked_user
 
 
 @transaction.atomic

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -99,13 +99,19 @@ STATIC_ROOT = BASE_DIR / "staticfiles"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 AUTH_USER_MODEL = "users.User"
 AUTHENTICATION_BACKENDS = ["django.contrib.auth.backends.ModelBackend"]
+AUTH_PASSWORD_VALIDATORS = [
+    {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
+    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
+    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
+    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
+]
 
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.SessionAuthentication",
     ],
     "DEFAULT_PERMISSION_CLASSES": [
-        "rest_framework.permissions.IsAuthenticated",
+        "apps.users.api.permissions.IsAuthenticatedAndPasswordResetComplete",
     ],
     "DEFAULT_RENDERER_CLASSES": [
         "rest_framework.renderers.JSONRenderer",

--- a/backend/tests/integration/test_auth_api.py
+++ b/backend/tests/integration/test_auth_api.py
@@ -1,10 +1,38 @@
 import pytest
+from django.test import override_settings
+from django.urls import include, path
 from django.contrib.auth import get_user_model
 from django.utils import timezone
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
 from rest_framework.test import APIClient
+from rest_framework.views import APIView
+
+from apps.users.api.permissions import IsAuthenticatedAndPasswordResetComplete
 
 
 pytestmark = pytest.mark.django_db
+
+
+class ProtectedAppView(APIView):
+    permission_classes = [IsAuthenticatedAndPasswordResetComplete]
+
+    def get(self, request):
+        return Response({"status": "ok"})
+
+
+class PublicProbeView(APIView):
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        return Response({"status": "ok"})
+
+
+urlpatterns = [
+    path("", include("config.urls")),
+    path("api/test/protected-app/", ProtectedAppView.as_view(), name="test-protected-app"),
+    path("api/test/public-probe/", PublicProbeView.as_view(), name="test-public-probe"),
+]
 
 
 def create_user(**overrides):
@@ -59,6 +87,125 @@ def test_login_success_indicates_when_password_reset_is_required():
     assert response.status_code == 200
     assert response.json()["requires_password_reset"] is True
     assert response.json()["user"]["must_reset_password"] is True
+
+
+def test_force_reset_password_succeeds_and_returns_refreshed_session_user():
+    user = create_user(email="force-reset@example.com", must_reset_password=True)
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.post(
+        "/api/auth/force-reset-password",
+        {"new_password": "better-password-123"},
+        format="json",
+    )
+
+    user.refresh_from_db()
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "user": {
+            "id": str(user.id),
+            "email": user.email,
+            "name": user.name,
+            "is_admin": False,
+            "must_reset_password": False,
+        },
+        "requires_password_reset": False,
+    }
+    assert user.must_reset_password is False
+    assert user.check_password("better-password-123") is True
+    assert user.check_password("valid-password") is False
+
+
+def test_force_reset_password_rejects_invalid_new_password_with_field_errors():
+    user = create_user(email="weak-password@example.com", must_reset_password=True)
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.post(
+        "/api/auth/force-reset-password",
+        {"new_password": "short"},
+        format="json",
+    )
+
+    user.refresh_from_db()
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": {
+            "code": "VALIDATION_ERROR",
+            "message": "Invalid input",
+            "details": {
+                "new_password": [
+                    "This password is too short. It must contain at least 8 characters."
+                ]
+            },
+        }
+    }
+    assert user.must_reset_password is True
+    assert user.check_password("valid-password") is True
+
+
+def test_force_reset_password_requires_authentication():
+    client = APIClient()
+
+    response = client.post(
+        "/api/auth/force-reset-password",
+        {"new_password": "better-password-123"},
+        format="json",
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {
+        "error": {
+            "code": "UNAUTHENTICATED",
+            "message": "Authentication required.",
+            "details": {},
+        }
+    }
+
+
+def test_force_reset_password_rejects_users_who_do_not_require_reset():
+    user = create_user(email="no-reset-needed@example.com", must_reset_password=False)
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.post(
+        "/api/auth/force-reset-password",
+        {"new_password": "better-password-123"},
+        format="json",
+    )
+
+    user.refresh_from_db()
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "error": {
+            "code": "PASSWORD_RESET_NOT_REQUIRED",
+            "message": "Password reset is not required for this user.",
+            "details": {},
+        }
+    }
+    assert user.must_reset_password is False
+    assert user.check_password("valid-password") is True
+
+
+def test_current_user_returns_authenticated_profile_for_reset_required_user():
+    user = create_user(email="reset-bootstrap@example.com", must_reset_password=True)
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.get("/api/auth/me")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "id": str(user.id),
+        "email": user.email,
+        "name": user.name,
+        "is_admin": False,
+        "must_reset_password": True,
+    }
 
 
 def test_login_requires_csrf_token():
@@ -140,6 +287,63 @@ def test_current_user_returns_authenticated_profile():
         "is_admin": False,
         "must_reset_password": False,
     }
+
+
+@override_settings(ROOT_URLCONF=__name__)
+def test_reset_required_user_is_blocked_from_protected_endpoints():
+    user = create_user(email="blocked@example.com", must_reset_password=True)
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.get("/api/test/protected-app/")
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Password reset required."}
+
+
+@override_settings(ROOT_URLCONF=__name__)
+def test_reset_complete_user_can_access_protected_endpoints():
+    user = create_user(email="allowed@example.com", must_reset_password=False)
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.get("/api/test/protected-app/")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+@override_settings(ROOT_URLCONF=__name__)
+def test_public_endpoints_can_still_allow_reset_required_users_when_explicitly_configured():
+    user = create_user(email="public@example.com", must_reset_password=True)
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.get("/api/test/public-probe/")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+@override_settings(ROOT_URLCONF=__name__)
+def test_reset_required_user_can_access_protected_endpoints_after_successful_forced_reset():
+    user = create_user(email="post-reset@example.com", must_reset_password=True)
+    client = APIClient()
+    client.force_login(user)
+
+    reset_response = client.post(
+        "/api/auth/force-reset-password",
+        {"new_password": "better-password-123"},
+        format="json",
+    )
+    protected_response = client.get("/api/test/protected-app/")
+
+    user.refresh_from_db()
+
+    assert reset_response.status_code == 200
+    assert user.must_reset_password is False
+    assert protected_response.status_code == 200
+    assert protected_response.json() == {"status": "ok"}
 
 
 def test_current_user_requires_authentication():

--- a/frontend/src/features/auth/AuthFlow.test.tsx
+++ b/frontend/src/features/auth/AuthFlow.test.tsx
@@ -69,6 +69,48 @@ describe("auth flow", () => {
     expect(loginRequestHeaders.get("X-CSRFToken")).toBe("test-token");
   });
 
+  it("redirects to the reset-required shell when login returns a forced reset state", async () => {
+    mockFetchSequence([
+      jsonResponse({
+        status: 401,
+        body: {
+          error: {
+            code: "UNAUTHENTICATED",
+            message: "Authentication required.",
+            details: {},
+          },
+        },
+      }),
+      jsonResponse({
+        body: {
+          user: {
+            id: "user-2",
+            email: "temp@example.com",
+            name: "Temp User",
+            is_admin: false,
+            must_reset_password: false,
+          },
+          requires_password_reset: true,
+        },
+      }),
+    ]);
+
+    const user = userEvent.setup();
+    renderApp(["/login"], { cookie: "csrftoken=test-token; path=/" });
+    await user.type(await screen.findByLabelText(/email/i), "temp@example.com");
+    await user.type(screen.getByLabelText(/password/i), "TempPassword123!");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    expect(
+      await screen.findByRole("heading", {
+        name: /your temporary password must be replaced/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/temp user is signed in with/i),
+    ).toBeInTheDocument();
+  });
+
   it("shows the generic invalid credentials error", async () => {
     mockFetchSequence([
       jsonResponse({
@@ -151,5 +193,198 @@ describe("auth flow", () => {
         screen.queryByRole("heading", { name: /session established/i }),
       ).not.toBeInTheDocument();
     });
+  });
+
+  it("redirects reset-required users away from the login route", async () => {
+    mockFetchSequence([
+      jsonResponse({
+        body: {
+          id: "user-2",
+          email: "temp@example.com",
+          name: "Temp User",
+          is_admin: false,
+          must_reset_password: true,
+        },
+      }),
+    ]);
+
+    renderApp(["/login"]);
+
+    expect(
+      await screen.findByRole("heading", {
+        name: /your temporary password must be replaced/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: /user login/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("submits a forced password reset and enters the authenticated shell", async () => {
+    const fetchMock = mockFetchSequence([
+      jsonResponse({
+        body: {
+          id: "user-2",
+          email: "temp@example.com",
+          name: "Temp User",
+          is_admin: false,
+          must_reset_password: true,
+        },
+      }),
+      jsonResponse({
+        body: {
+          id: "user-2",
+          email: "temp@example.com",
+          name: "Temp User",
+          is_admin: false,
+          must_reset_password: false,
+        },
+      }),
+    ]);
+
+    const user = userEvent.setup();
+    renderApp(["/reset-password"], { cookie: "csrftoken=test-token; path=/" });
+    await user.type(
+      await screen.findByLabelText(/^new password$/i),
+      "NewPassword123!",
+    );
+    await user.type(
+      screen.getByLabelText(/^confirm new password$/i),
+      "NewPassword123!",
+    );
+    await user.click(screen.getByRole("button", { name: /set new password/i }));
+
+    expect(
+      await screen.findByRole("heading", { name: /session established/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", {
+        name: /your temporary password must be replaced/i,
+      }),
+    ).not.toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("/api/auth/force-reset-password");
+    const resetRequestHeaders = new Headers(fetchMock.mock.calls[1]?.[1]?.headers);
+    expect(resetRequestHeaders.get("X-CSRFToken")).toBe("test-token");
+    expect(fetchMock.mock.calls[1]?.[1]?.body).toBe(
+      JSON.stringify({ new_password: "NewPassword123!" }),
+    );
+  });
+
+  it("shows server-side reset validation errors on the form", async () => {
+    mockFetchSequence([
+      jsonResponse({
+        body: {
+          id: "user-2",
+          email: "temp@example.com",
+          name: "Temp User",
+          is_admin: false,
+          must_reset_password: true,
+        },
+      }),
+      jsonResponse({
+        status: 400,
+        body: {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Invalid input",
+            details: {
+              new_password: ["This password is too common."],
+            },
+          },
+        },
+      }),
+    ]);
+
+    const user = userEvent.setup();
+    renderApp(["/reset-password"], { cookie: "csrftoken=test-token; path=/" });
+    await user.type(
+      await screen.findByLabelText(/^new password$/i),
+      "CommonPassword123!",
+    );
+    await user.type(
+      screen.getByLabelText(/^confirm new password$/i),
+      "CommonPassword123!",
+    );
+    await user.click(screen.getByRole("button", { name: /set new password/i }));
+
+    expect(
+      await screen.findByText("This password is too common."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        name: /your temporary password must be replaced/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps reset route guards aligned after the forced reset succeeds", async () => {
+    const fetchMock = mockFetchSequence([
+      jsonResponse({
+        body: {
+          id: "user-2",
+          email: "temp@example.com",
+          name: "Temp User",
+          is_admin: false,
+          must_reset_password: true,
+        },
+      }),
+      jsonResponse({
+        body: {
+          id: "user-2",
+          email: "temp@example.com",
+          name: "Temp User",
+          is_admin: false,
+          must_reset_password: false,
+        },
+      }),
+    ]);
+
+    const user = userEvent.setup();
+    renderApp(["/reset-password"], { cookie: "csrftoken=test-token; path=/" });
+    await user.type(
+      await screen.findByLabelText(/^new password$/i),
+      "AnotherPassword123!",
+    );
+    await user.type(
+      screen.getByLabelText(/^confirm new password$/i),
+      "AnotherPassword123!",
+    );
+    await user.click(screen.getByRole("button", { name: /set new password/i }));
+
+    await screen.findByRole("heading", { name: /session established/i });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("heading", {
+          name: /set a permanent password/i,
+        }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("redirects non-reset users away from the reset-password route", async () => {
+    mockFetchSequence([
+      jsonResponse({
+        body: {
+          id: "user-1",
+          email: "jane@example.com",
+          name: "Jane Doe",
+          is_admin: false,
+          must_reset_password: false,
+        },
+      }),
+    ]);
+
+    renderApp(["/reset-password"]);
+
+    expect(
+      await screen.findByRole("heading", { name: /session established/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", {
+        name: /your temporary password must be replaced/i,
+      }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/auth/api/authApi.ts
+++ b/frontend/src/features/auth/api/authApi.ts
@@ -2,11 +2,22 @@ import { apiRequest, isApiError } from "../../../api/client";
 import { type LoginFormValues } from "../schemas/loginSchema";
 import { type LoginResponse, type SessionUser } from "../types";
 
+type ForceResetPasswordRequest = {
+  new_password: string;
+};
+
+type SessionResponse = SessionUser | { user: SessionUser };
+
 function normalizeSessionUser(user: SessionUser) {
   return {
     ...user,
     must_reset_password: Boolean(user.must_reset_password),
   };
+}
+
+function extractSessionUser(response: SessionResponse) {
+  const user = "user" in response ? response.user : response;
+  return normalizeSessionUser(user);
 }
 
 export async function login(values: LoginFormValues): Promise<SessionUser> {
@@ -15,7 +26,7 @@ export async function login(values: LoginFormValues): Promise<SessionUser> {
     body: JSON.stringify(values),
   });
 
-  const user = normalizeSessionUser(response.user);
+  const user = extractSessionUser(response);
   return {
     ...user,
     must_reset_password:
@@ -23,10 +34,21 @@ export async function login(values: LoginFormValues): Promise<SessionUser> {
   };
 }
 
+export async function forceResetPassword(
+  values: ForceResetPasswordRequest,
+): Promise<SessionUser> {
+  const response = await apiRequest<SessionResponse>("/auth/force-reset-password", {
+    method: "POST",
+    body: JSON.stringify(values),
+  });
+
+  return extractSessionUser(response);
+}
+
 export async function fetchSession(): Promise<SessionUser | null> {
   try {
     const session = await apiRequest<SessionUser>("/auth/me");
-    return normalizeSessionUser(session);
+    return extractSessionUser(session);
   } catch (error) {
     if (isApiError(error) && error.status === 401) {
       return null;

--- a/frontend/src/features/auth/hooks/useForceResetPasswordMutation.ts
+++ b/frontend/src/features/auth/hooks/useForceResetPasswordMutation.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+
+import { forceResetPassword } from "../api/authApi";
+import { type ForceResetPasswordFormValues } from "../schemas/forceResetPasswordSchema";
+import { sessionQueryKey } from "./useSessionQuery";
+
+export function useForceResetPasswordMutation() {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: ({ new_password }: ForceResetPasswordFormValues) =>
+      forceResetPassword({ new_password }),
+    onSuccess: (session) => {
+      queryClient.setQueryData(sessionQueryKey, session);
+      navigate(session.must_reset_password ? "/reset-password" : "/");
+    },
+  });
+}

--- a/frontend/src/features/auth/pages/ResetRequiredPage.tsx
+++ b/frontend/src/features/auth/pages/ResetRequiredPage.tsx
@@ -1,29 +1,116 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+
+import { isApiError } from "../../../api/client";
+import { Button } from "../../../components/Button";
+import { Field } from "../../../components/Field";
 import { Panel } from "../../../components/Panel";
 import { StatusMessage } from "../../../components/StatusMessage";
 import { type SessionUser } from "../types";
 import { AuthFrame } from "../components/AuthFrame";
+import { useForceResetPasswordMutation } from "../hooks/useForceResetPasswordMutation";
+import {
+  forceResetPasswordSchema,
+  type ForceResetPasswordFormValues,
+} from "../schemas/forceResetPasswordSchema";
 
 type ResetRequiredPageProps = {
   user: SessionUser;
 };
 
+function getDetailMessages(detail: unknown): string[] {
+  if (typeof detail === "string") {
+    return [detail];
+  }
+
+  if (Array.isArray(detail)) {
+    return detail.filter(
+      (message): message is string => typeof message === "string" && message.length > 0,
+    );
+  }
+
+  return [];
+}
+
 export function ResetRequiredPage({ user }: ResetRequiredPageProps) {
+  const resetPasswordMutation = useForceResetPasswordMutation();
+  const {
+    formState: { errors },
+    handleSubmit,
+    register,
+  } = useForm<ForceResetPasswordFormValues>({
+    defaultValues: {
+      new_password: "",
+      confirm_password: "",
+    },
+    resolver: zodResolver(forceResetPasswordSchema),
+  });
+
+  const resetError = isApiError(resetPasswordMutation.error)
+    ? resetPasswordMutation.error
+    : null;
+  const serverPasswordError = getDetailMessages(
+    resetError?.details.new_password,
+  )[0];
+  const serverErrorMessage =
+    Object.entries(resetError?.details ?? {})
+      .flatMap(([field, detail]) =>
+        field === "new_password" ? [] : getDetailMessages(detail),
+      )[0] ??
+    (resetError && !serverPasswordError ? resetError.message : null);
+
   return (
     <AuthFrame
       eyebrow="Password reset required"
       title="Your temporary password must be replaced"
-      summary="This slice stops at the guarded reset-required shell state. The password reset submission flow is intentionally not implemented here."
+      summary="Choose a permanent password to leave the restricted auth shell. The backend still applies the full password policy after this explicit client-side validation."
     >
       <Panel className="auth-panel">
         <div className="panel-heading">
-          <h2 className="panel-heading__title">Authenticated, but blocked from the main shell</h2>
+          <h2 className="panel-heading__title">Set a permanent password</h2>
           <p className="panel-heading__body">
             {user.name} is signed in with <strong>{user.email}</strong>.
           </p>
         </div>
-        <StatusMessage tone="warning" title="Next auth slice required">
-          Password reset submission, logout, and session expiration stay out of scope for this foundation work.
+        <StatusMessage title="Main app access is still blocked">
+          Finish this reset before you can enter the authenticated shell.
         </StatusMessage>
+        <form
+          className="form-stack"
+          onSubmit={handleSubmit((values) => {
+            resetPasswordMutation.reset();
+            resetPasswordMutation.mutate(values);
+          })}
+        >
+          <Field
+            autoComplete="new-password"
+            error={errors.new_password?.message ?? serverPasswordError}
+            label="New password"
+            type="password"
+            {...register("new_password")}
+          />
+          <Field
+            autoComplete="new-password"
+            error={errors.confirm_password?.message}
+            label="Confirm new password"
+            type="password"
+            {...register("confirm_password")}
+          />
+          {serverErrorMessage ? (
+            <StatusMessage tone="error" title="Password reset failed">
+              {serverErrorMessage}
+            </StatusMessage>
+          ) : null}
+          <Button
+            disabled={resetPasswordMutation.isPending}
+            fullWidth
+            type="submit"
+          >
+            {resetPasswordMutation.isPending
+              ? "Updating password..."
+              : "Set new password"}
+          </Button>
+        </form>
       </Panel>
     </AuthFrame>
   );

--- a/frontend/src/features/auth/schemas/forceResetPasswordSchema.ts
+++ b/frontend/src/features/auth/schemas/forceResetPasswordSchema.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+const minimumPasswordLength = 8;
+
+export const forceResetPasswordSchema = z
+  .object({
+    new_password: z
+      .string()
+      .min(1, "Enter a new password.")
+      .min(
+        minimumPasswordLength,
+        `Use at least ${minimumPasswordLength} characters.`,
+      ),
+    confirm_password: z.string().min(1, "Confirm your new password."),
+  })
+  .refine((values) => values.new_password === values.confirm_password, {
+    message: "Passwords do not match.",
+    path: ["confirm_password"],
+  });
+
+export type ForceResetPasswordFormValues = z.infer<
+  typeof forceResetPasswordSchema
+>;

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -12,6 +12,12 @@ Object.assign(globalThis, {
 
 afterEach(() => {
   cleanup();
+  document.cookie.split(";").forEach((cookie) => {
+    const cookieName = cookie.split("=")[0]?.trim();
+    if (cookieName) {
+      document.cookie = `${cookieName}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
+    }
+  });
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });

--- a/issues/stories/us-002-forced-first-login-password-reset.md
+++ b/issues/stories/us-002-forced-first-login-password-reset.md
@@ -1,4 +1,18 @@
-﻿# US-002 - Forced First-Login Password Reset  ## Metadata - Area: 1. Authentication and Session Management - GitHub labels: `user-story`, `mvp`, `area:auth` - Suggested status: `Backlog` - Suggested wave: `Wave 1` - Depends on: US-001 - Parallelization note: Start once dependencies are done; run in parallel with other stories in the same wave that do not share blocking dependencies.  ## User Story **As a** newly created user  
+# US-002 - Forced First-Login Password Reset
+
+## Metadata
+
+- Area: `1. Authentication and Session Management`
+- GitHub labels: `user-story`, `mvp`, `area:auth`
+- Suggested status: `:owner-review`
+- Suggested wave: `Wave 1`
+- Depends on: `US-001`
+- Slice type: auth follow-up on top of the login foundation
+- Parallelization note: Start once dependencies are done; run in parallel only with stories that do not need the same auth contract changes.
+
+## User Story
+
+**As a** newly created user  
 **I want** to reset my temporary password on first login  
 **So that** only I know my long-term password.
 
@@ -14,43 +28,160 @@
 
 **Given** I have not completed the forced password reset  
 **When** I attempt to access any main application page  
-**Then** the system blocks access and redirects me back to password reset.  ## Implementation Breakdown **Kanban lane:** Backlog â†’ Ready â†’ Red â†’ Green â†’ Refactor â†’ Review / QA â†’ Done  
-**Definition of Done:** All listed layer tasks are complete, reviewed, tested, and traceable to the story acceptance criteria.
+**Then** the system blocks access and redirects me back to password reset.
 
-### Database
-- [ ] Confirm user fields support auth state: `is_active`, `deleted_at`, `must_reset_password`, `last_login_at`.
-- [ ] Add indexes/constraints required for email uniqueness and active-user lookup.
+## Dependency Slice Required Before US-002
 
-### Backend/API
-- [ ] Implement/validate session endpoint behavior and generic auth errors.
-- [ ] Enforce active, non-deleted user checks before creating sessions.
-- [ ] Add service-level handling for `must_reset_password` and allowed endpoints.
-- [ ] Emit application logs for security-relevant auth events.
+Build and validate only the auth foundation required to make `US-002` buildable.
 
-### Frontend/UI
-- [ ] Build guarded route behavior for authenticated, unauthenticated, and reset-required users.
-- [ ] Display validation, generic credential, expired-session, and rate-limit states.
-- [ ] Attach CSRF tokens and credentials on unsafe requests.
+This prerequisite slice is accepted through `US-001`, but it exists specifically to unblock the forced-reset story without leaking into logout, session-expiration, admin CRUD, or project and task work.
 
-### TDD â€” Red: Write Failing Tests First
-- [ ] Map each Given/When/Then acceptance criterion to automated tests.
-- [ ] Add happy-path tests before implementation.
-- [ ] Add validation, permission, and edge-case tests before implementation.
-- [ ] Run the tests and confirm they fail for the expected reason.
-- [ ] Unit test valid/invalid credentials, inactive users, deleted users, and reset-required users.
-- [ ] Integration test full browser/API auth flow and session expiry behavior.
+### Out Of Scope For This Dependency Slice
 
-### TDD â€” Green: Implement Minimum Passing Code
-- [ ] Implement only the smallest database/backend/frontend change needed to pass the failing tests.
-- [ ] Run the story-level test set and confirm all new tests pass.
-- [ ] Confirm existing regression tests still pass.
+- forced password reset submission endpoint
+- forced password reset form submission
+- logout endpoint or UI
+- session expiration behavior
+- admin user CRUD
+- project, membership, task, notification, or comment flows
 
-### TDD â€” Refactor: Improve Safely
-- [ ] Refactor duplicated logic into services, validators, hooks, or shared components.
-- [ ] Confirm permissions, structured errors, soft-delete behavior, and edge cases remain covered.
-- [ ] Re-run unit, integration, and relevant frontend tests after refactoring.
+## Execution Breakdown
 
-### Review / QA Checklist
-- [ ] Acceptance criteria from the user story are verified manually or by automated tests.
-- [ ] Structured API errors, permissions, and edge cases are validated where applicable.
-- [ ] Documentation or developer notes are updated if behavior is non-obvious.
+### Backend Slice
+
+- [x] Confirm the custom `users` app owns the auth-state fields required by `US-002`:
+  - `is_active`
+  - `deleted_at`
+  - `must_reset_password`
+  - `last_login_at`
+- [x] Configure Django to use the custom email-based auth model.
+- [x] Implement and validate the auth contract under the owning `users` module:
+  - `POST /api/auth/login`
+  - `GET /api/auth/me`
+- [x] Return structured API errors for invalid credentials and unauthenticated session fetches.
+- [x] Enforce active and non-deleted user checks before creating sessions.
+- [x] Return session profile data needed by the frontend shell:
+  - `id`
+  - `email`
+  - `name`
+  - `is_admin`
+  - `must_reset_password`
+- [x] Expose reset-required session state through login and session bootstrap so the frontend can gate `US-002`.
+- [x] Add a shared backend permission baseline so reset-required users are blocked from normal protected API endpoints unless an endpoint explicitly opts out.
+- [ ] Implement the forced password reset submission endpoint in the follow-up `US-002` delivery slice.
+
+### Frontend Slice
+
+- [x] Build guarded auth-shell behavior for:
+  - unauthenticated users
+  - authenticated users
+  - authenticated reset-required users
+- [x] Add a shared API client foundation that:
+  - centralizes the API base URL
+  - includes credentials on requests
+  - parses structured API errors
+  - provides one place for later CSRF and auth response handling
+- [x] Add the login screen and session bootstrap flow.
+- [x] Route reset-required users into a dedicated shell state instead of the main application shell.
+- [x] Keep the reset-required route as a placeholder shell only. Do not add password reset submission yet.
+- [ ] Implement the forced password reset form and submission behavior in the follow-up `US-002` delivery slice.
+
+### Test Slice
+
+- [x] Backend tests cover:
+  - successful login
+  - invalid credentials
+  - inactive user rejection
+  - soft-deleted user rejection
+  - reset-required login response
+  - authenticated session bootstrap
+  - unauthenticated session bootstrap
+  - reset-required session bootstrap payload
+  - reset-required user rejection on protected endpoints
+- [x] Frontend tests cover:
+  - successful login transition into authenticated shell
+  - invalid credential error presentation
+  - existing session bootstrap into authenticated shell
+  - reset-required session routing into the blocked shell state
+- [x] Keep the auth test scaffolding reusable for the actual `US-002` implementation slice.
+- [ ] Add tests for the password reset submission and main-app blocking behavior when the actual `US-002` flow is implemented.
+
+## Dependencies And Parallel Work
+
+### Dependency Notes
+
+- `US-002` depends directly on `US-001` because the forced-reset flow requires a working session and login contract first.
+- The backend login/session contract must already expose `must_reset_password` before the frontend can route users into the reset-required shell.
+- The guarded reset-required shell is a prerequisite, but it is not the full `US-002` implementation.
+- `US-003 Logout`, `US-004 Session Expiration`, `US-057 CSRF Protection`, and `US-058 Rate-Limit Authentication Endpoints` should remain separate follow-up stories rather than expanding this slice.
+
+### Parallel Work
+
+- Once the auth foundation slice is passing, the forced-reset submission endpoint and the forced-reset UI can be developed in parallel if they keep the response contract explicit.
+- Stories that only need authenticated shell presence may start after this dependency slice passes, but they must not assume logout, session expiry, or admin user management already exist.
+
+## Definition Of Done For This Dependency Slice
+
+- The custom backend user model exists and is the active Django auth user model.
+- `POST /api/auth/login` creates a session only for valid active non-deleted users and returns the expected session payload.
+- `GET /api/auth/me` returns the authenticated session user payload or an unauthenticated error envelope.
+- The backend default permission baseline blocks reset-required users from normal protected API endpoints while still allowing the auth bootstrap flow to function.
+- Invalid, inactive, and soft-deleted login attempts all return the same generic invalid-credentials error shape.
+- Successful login updates `last_login_at`.
+- Frontend boots through session lookup and shows either:
+  - login page
+  - authenticated shell
+  - reset-required shell state
+- The reset-required shell state blocks normal application entry even though the actual password reset submission flow is not implemented yet.
+- Backend and frontend automated tests for the dependency slice pass.
+- Scope remains limited to the auth foundation required to make `US-002` buildable.
+
+## Open Blockers Or Follow-Ups
+
+- Rate limiting and richer auth observability remain follow-up work under their own stories.
+
+## Actual US-002 Delivery Slice
+
+Implement only the forced first-login password reset behavior on top of the completed auth foundation.
+
+### Backend Slice
+
+- [x] Add `POST /api/auth/force-reset-password` under the `users` module.
+- [x] Allow reset-required authenticated users to access this endpoint while keeping the default protected-endpoint block in place.
+- [x] Validate the new password with Django's built-in password validators.
+- [x] Reject invalid submissions with the repository error envelope and field-level details.
+- [x] Update the authenticated user's password and set `must_reset_password = false` on success.
+- [x] Return the refreshed session user payload needed by the frontend shell.
+- [x] Add backend tests for:
+  - successful forced reset
+  - invalid new password
+  - unauthenticated forced reset rejection
+  - non-reset-required user behavior on the forced-reset endpoint
+  - protected-endpoint access after successful forced reset
+
+### Frontend Slice
+
+- [x] Replace the reset-required placeholder shell with an actual forced-reset form.
+- [x] Add client-side validation aligned to the backend contract where useful, without duplicating all backend password rules.
+- [x] Submit the new password to `POST /api/auth/force-reset-password`.
+- [x] Surface validation and server error states clearly on the reset page.
+- [x] Update the cached session state from the successful reset response.
+- [x] Redirect the user into the authenticated shell after the forced reset succeeds.
+- [x] Keep `/login` and `/reset-password` route guard behavior aligned with the updated session state.
+
+### Test Slice
+
+- [x] Extend backend auth integration tests for the forced-reset endpoint and post-reset access behavior.
+- [x] Extend frontend auth flow tests for:
+  - successful password reset submission
+  - validation or server-error presentation
+  - redirect into the authenticated shell after success
+- [x] Run the smallest meaningful backend and frontend auth test sets for this story.
+
+### Out Of Scope For This Delivery Slice
+
+- normal change-password flow (`POST /auth/change-password`)
+- logout
+- session expiration
+- admin password reset for other users
+- rate limiting beyond the existing story boundary


### PR DESCRIPTION
## Summary
- add the backend forced password reset endpoint, password-policy validation, and reset-required permission baseline
- replace the frontend reset-required placeholder with the real password reset flow and session cache update
- extend backend and frontend auth tests and sync the local story breakdown for `US-002`

## Notes
- stacked on top of #79 because `US-002` depends on the `US-001` auth foundation branch
- keeps logout, session expiration, admin CRUD, and broader app flows out of scope

## Validation
- `pytest tests/integration/test_auth_api.py` -> `20 passed`
- `npm run test:run -- src/features/auth/AuthFlow.test.tsx` -> `10 passed`

## Issue
- refs #7