### PR TITLE
Implement US-003 logout

### DIFF
--- a/backend/apps/users/api/urls.py
+++ b/backend/apps/users/api/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
-from .views import CurrentUserView, ForceResetPasswordView, LoginView
+from .views import CurrentUserView, ForceResetPasswordView, LoginView, LogoutView
 
 urlpatterns = [
     path("auth/login", LoginView.as_view(), name="auth-login"),
+    path("auth/logout", LogoutView.as_view(), name="auth-logout"),
     path("auth/me", CurrentUserView.as_view(), name="auth-me"),
     path(
         "auth/force-reset-password",

--- a/backend/apps/users/api/views.py
+++ b/backend/apps/users/api/views.py
@@ -10,6 +10,7 @@ from apps.users.domain.services import (
     authenticate_user_session,
     force_reset_password,
     get_active_session_user,
+    logout_user_session,
     PasswordResetNotRequiredError,
     PasswordValidationFailedError,
     serialize_session_user,
@@ -152,3 +153,19 @@ class ForceResetPasswordView(APIView):
             },
             status=status.HTTP_200_OK,
         )
+
+
+@method_decorator(csrf_protect, name="dispatch")
+class LogoutView(APIView):
+    permission_classes = [permissions.AllowAny]
+
+    def post(self, request):
+        if not logout_user_session(request=request):
+            return error_response(
+                code="UNAUTHENTICATED",
+                message="Authentication required.",
+                details={},
+                status_code=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/apps/users/domain/services.py
+++ b/backend/apps/users/domain/services.py
@@ -68,6 +68,15 @@ def get_active_session_user(request):
     return user
 
 
+def logout_user_session(*, request) -> bool:
+    session_user = get_active_session_user(request)
+    if session_user is None:
+        return False
+
+    django_logout(request)
+    return True
+
+
 def validate_user_password(*, user, password: str) -> None:
     try:
         if getattr(settings, "AUTH_PASSWORD_VALIDATORS", None):

--- a/backend/tests/integration/test_auth_api.py
+++ b/backend/tests/integration/test_auth_api.py
@@ -166,6 +166,52 @@ def test_force_reset_password_requires_authentication():
     }
 
 
+def test_logout_invalidates_the_authenticated_session():
+    user = create_user(email="logout@example.com", must_reset_password=False)
+    client = APIClient()
+    client.force_login(user)
+
+    logout_response = client.post("/api/auth/logout")
+    session_response = client.get("/api/auth/me")
+
+    assert logout_response.status_code == 204
+    assert session_response.status_code == 401
+    assert session_response.json() == {
+        "error": {
+            "code": "UNAUTHENTICATED",
+            "message": "Authentication required.",
+            "details": {},
+        }
+    }
+
+
+def test_logout_allows_reset_required_users_to_end_their_session():
+    user = create_user(email="reset-logout@example.com", must_reset_password=True)
+    client = APIClient()
+    client.force_login(user)
+
+    logout_response = client.post("/api/auth/logout")
+    session_response = client.get("/api/auth/me")
+
+    assert logout_response.status_code == 204
+    assert session_response.status_code == 401
+
+
+def test_logout_requires_authentication():
+    client = APIClient()
+
+    response = client.post("/api/auth/logout")
+
+    assert response.status_code == 401
+    assert response.json() == {
+        "error": {
+            "code": "UNAUTHENTICATED",
+            "message": "Authentication required.",
+            "details": {},
+        }
+    }
+
+
 def test_force_reset_password_rejects_users_who_do_not_require_reset():
     user = create_user(email="no-reset-needed@example.com", must_reset_password=False)
     client = APIClient()

--- a/frontend/src/features/auth/AuthFlow.test.tsx
+++ b/frontend/src/features/auth/AuthFlow.test.tsx
@@ -220,6 +220,37 @@ describe("auth flow", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("logs out from the authenticated shell and returns to the login route", async () => {
+    const fetchMock = mockFetchSequence([
+      jsonResponse({
+        body: {
+          id: "user-1",
+          email: "jane@example.com",
+          name: "Jane Doe",
+          is_admin: false,
+          must_reset_password: false,
+        },
+      }),
+      new Response(null, { status: 204 }),
+    ]);
+
+    const user = userEvent.setup();
+    renderApp(["/"], { cookie: "csrftoken=test-token; path=/" });
+    await user.click(
+      await screen.findByRole("button", {
+        name: /sign out/i,
+      }),
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: /user login/i }),
+    ).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("/api/auth/logout");
+    const logoutRequestHeaders = new Headers(fetchMock.mock.calls[1]?.[1]?.headers);
+    expect(logoutRequestHeaders.get("X-CSRFToken")).toBe("test-token");
+  });
+
   it("submits a forced password reset and enters the authenticated shell", async () => {
     const fetchMock = mockFetchSequence([
       jsonResponse({
@@ -316,6 +347,35 @@ describe("auth flow", () => {
         name: /your temporary password must be replaced/i,
       }),
     ).toBeInTheDocument();
+  });
+
+  it("logs out from the reset-required shell and returns to the login route", async () => {
+    const fetchMock = mockFetchSequence([
+      jsonResponse({
+        body: {
+          id: "user-2",
+          email: "temp@example.com",
+          name: "Temp User",
+          is_admin: false,
+          must_reset_password: true,
+        },
+      }),
+      new Response(null, { status: 204 }),
+    ]);
+
+    const user = userEvent.setup();
+    renderApp(["/reset-password"], { cookie: "csrftoken=test-token; path=/" });
+    await user.click(
+      await screen.findByRole("button", {
+        name: /sign out/i,
+      }),
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: /user login/i }),
+    ).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("/api/auth/logout");
   });
 
   it("keeps reset route guards aligned after the forced reset succeeds", async () => {

--- a/frontend/src/features/auth/api/authApi.ts
+++ b/frontend/src/features/auth/api/authApi.ts
@@ -45,6 +45,12 @@ export async function forceResetPassword(
   return extractSessionUser(response);
 }
 
+export async function logout(): Promise<void> {
+  await apiRequest<null>("/auth/logout", {
+    method: "POST",
+  });
+}
+
 export async function fetchSession(): Promise<SessionUser | null> {
   try {
     const session = await apiRequest<SessionUser>("/auth/me");

--- a/frontend/src/features/auth/hooks/useLogoutMutation.ts
+++ b/frontend/src/features/auth/hooks/useLogoutMutation.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+
+import { logout } from "../api/authApi";
+import { sessionQueryKey } from "./useSessionQuery";
+
+export function useLogoutMutation() {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: logout,
+    onSuccess: () => {
+      queryClient.setQueryData(sessionQueryKey, null);
+      navigate("/login");
+    },
+  });
+}

--- a/frontend/src/features/auth/pages/AppShellPage.tsx
+++ b/frontend/src/features/auth/pages/AppShellPage.tsx
@@ -1,4 +1,6 @@
+import { Button } from "../../../components/Button";
 import { Panel } from "../../../components/Panel";
+import { useLogoutMutation } from "../hooks/useLogoutMutation";
 import { type SessionUser } from "../types";
 
 type AppShellPageProps = {
@@ -6,6 +8,8 @@ type AppShellPageProps = {
 };
 
 export function AppShellPage({ user }: AppShellPageProps) {
+  const logoutMutation = useLogoutMutation();
+
   return (
     <main className="shell">
       <div className="shell__hero">
@@ -46,6 +50,14 @@ export function AppShellPage({ user }: AppShellPageProps) {
             <li>Session bootstrap query gates the shell</li>
             <li>Reset-required users are redirected out of the main shell</li>
           </ul>
+          <Button
+            disabled={logoutMutation.isPending}
+            onClick={() => logoutMutation.mutate()}
+            type="button"
+            variant="secondary"
+          >
+            {logoutMutation.isPending ? "Signing out..." : "Sign out"}
+          </Button>
         </Panel>
       </section>
     </main>

--- a/frontend/src/features/auth/pages/ResetRequiredPage.tsx
+++ b/frontend/src/features/auth/pages/ResetRequiredPage.tsx
@@ -9,6 +9,7 @@ import { StatusMessage } from "../../../components/StatusMessage";
 import { type SessionUser } from "../types";
 import { AuthFrame } from "../components/AuthFrame";
 import { useForceResetPasswordMutation } from "../hooks/useForceResetPasswordMutation";
+import { useLogoutMutation } from "../hooks/useLogoutMutation";
 import {
   forceResetPasswordSchema,
   type ForceResetPasswordFormValues,
@@ -34,6 +35,7 @@ function getDetailMessages(detail: unknown): string[] {
 
 export function ResetRequiredPage({ user }: ResetRequiredPageProps) {
   const resetPasswordMutation = useForceResetPasswordMutation();
+  const logoutMutation = useLogoutMutation();
   const {
     formState: { errors },
     handleSubmit,
@@ -109,6 +111,15 @@ export function ResetRequiredPage({ user }: ResetRequiredPageProps) {
             {resetPasswordMutation.isPending
               ? "Updating password..."
               : "Set new password"}
+          </Button>
+          <Button
+            disabled={logoutMutation.isPending}
+            fullWidth
+            onClick={() => logoutMutation.mutate()}
+            type="button"
+            variant="secondary"
+          >
+            {logoutMutation.isPending ? "Signing out..." : "Sign out"}
           </Button>
         </form>
       </Panel>

--- a/issues/stories/us-003-logout.md
+++ b/issues/stories/us-003-logout.md
@@ -1,4 +1,18 @@
-﻿# US-003 - Logout  ## Metadata - Area: 1. Authentication and Session Management - GitHub labels: `user-story`, `mvp`, `area:auth` - Suggested status: `Backlog` - Suggested wave: `Wave 1` - Depends on: US-001 - Parallelization note: Start once dependencies are done; run in parallel with other stories in the same wave that do not share blocking dependencies.  ## User Story **As a** user  
+# US-003 - Logout
+
+## Metadata
+
+- Area: `1. Authentication and Session Management`
+- GitHub labels: `user-story`, `mvp`, `area:auth`
+- Suggested status: `:owner-review`
+- Suggested wave: `Wave 1`
+- Depends on: `US-001`
+- Slice type: auth session termination on top of the existing session-based login flow
+- Parallelization note: Start once the auth foundation is in place. Keep session expiration, rate limiting, and broader shell features out of scope.
+
+## User Story
+
+**As a** user  
 **I want** to log out  
 **So that** my session is ended securely.
 
@@ -10,43 +24,66 @@
 
 **Given** I have logged out  
 **When** I attempt to access a protected page  
-**Then** I am redirected to login.  ## Implementation Breakdown **Kanban lane:** Backlog â†’ Ready â†’ Red â†’ Green â†’ Refactor â†’ Review / QA â†’ Done  
-**Definition of Done:** All listed layer tasks are complete, reviewed, tested, and traceable to the story acceptance criteria.
+**Then** I am redirected to login.
 
-### Database
-- [ ] Confirm user fields support auth state: `is_active`, `deleted_at`, `must_reset_password`, `last_login_at`.
-- [ ] Add indexes/constraints required for email uniqueness and active-user lookup.
+## Execution Breakdown
 
-### Backend/API
-- [ ] Implement/validate session endpoint behavior and generic auth errors.
-- [ ] Enforce active, non-deleted user checks before creating sessions.
-- [ ] Add service-level handling for `must_reset_password` and allowed endpoints.
-- [ ] Emit application logs for security-relevant auth events.
+### Backend Slice
 
-### Frontend/UI
-- [ ] Build guarded route behavior for authenticated, unauthenticated, and reset-required users.
-- [ ] Display validation, generic credential, expired-session, and rate-limit states.
-- [ ] Attach CSRF tokens and credentials on unsafe requests.
+- [x] Add `POST /api/auth/logout` under the `users` auth API.
+- [x] Allow authenticated users to call logout even when `must_reset_password = true`.
+- [x] Invalidate the current Django session and clear the session cookie through the normal logout flow.
+- [x] Return a simple success response that keeps the frontend contract explicit and does not add extra workflow meaning.
+- [x] Return the repository unauthenticated error envelope when logout is called without an active session.
+- [x] Keep logout transport logic in the API layer and session invalidation behavior in the `users` domain service.
 
-### TDD â€” Red: Write Failing Tests First
-- [ ] Map each Given/When/Then acceptance criterion to automated tests.
-- [ ] Add happy-path tests before implementation.
-- [ ] Add validation, permission, and edge-case tests before implementation.
-- [ ] Run the tests and confirm they fail for the expected reason.
-- [ ] Unit test valid/invalid credentials, inactive users, deleted users, and reset-required users.
-- [ ] Integration test full browser/API auth flow and session expiry behavior.
+### Frontend Slice
 
-### TDD â€” Green: Implement Minimum Passing Code
-- [ ] Implement only the smallest database/backend/frontend change needed to pass the failing tests.
-- [ ] Run the story-level test set and confirm all new tests pass.
-- [ ] Confirm existing regression tests still pass.
+- [x] Add shared logout API support to the auth feature.
+- [x] Add a logout mutation that clears the cached session state on success.
+- [x] Expose logout from the authenticated shell.
+- [x] Expose logout from the reset-required shell so forced-reset users can still end their session.
+- [x] Redirect the user to `/login` after successful logout.
+- [x] Keep protected-route behavior driven by the session query instead of duplicating auth state.
 
-### TDD â€” Refactor: Improve Safely
-- [ ] Refactor duplicated logic into services, validators, hooks, or shared components.
-- [ ] Confirm permissions, structured errors, soft-delete behavior, and edge cases remain covered.
-- [ ] Re-run unit, integration, and relevant frontend tests after refactoring.
+### Test Slice
 
-### Review / QA Checklist
-- [ ] Acceptance criteria from the user story are verified manually or by automated tests.
-- [ ] Structured API errors, permissions, and edge cases are validated where applicable.
-- [ ] Documentation or developer notes are updated if behavior is non-obvious.
+- [x] Backend tests cover:
+  - successful logout for an authenticated user
+  - protected endpoint rejection after logout
+  - logout for a reset-required authenticated user
+  - unauthenticated logout rejection
+- [x] Frontend tests cover:
+  - logout from the authenticated shell
+  - logout from the reset-required shell
+  - redirect back to login after logout
+  - CSRF attachment on the logout request
+- [x] Run the focused backend and frontend auth test sets for this story.
+
+## Dependencies And Parallel Work
+
+### Dependency Notes
+
+- `US-003` depends on the existing session-based auth foundation from `US-001`.
+- The endpoint contract must remain compatible with the shared API client and current session query behavior.
+- Logout must remain separate from `US-004 Session Expiration`; this slice only handles explicit user-initiated session termination.
+- Because the current working branch already contains the forced-reset flow, this implementation must preserve the security rule that reset-required users may access `/auth/logout`.
+
+### Parallel Work
+
+- Backend and frontend implementation can proceed in parallel once the logout response contract is fixed.
+- Session expiration handling, idle timeout UX, and auth rate limiting are follow-up stories and should not be folded into this slice.
+
+## Definition Of Done
+
+- `POST /api/auth/logout` exists and terminates the current session for authenticated users.
+- Calling logout without an active session returns the structured unauthenticated error envelope.
+- Authenticated users in both the normal shell and reset-required shell can log out.
+- After logout, the frontend cached session becomes unauthenticated and protected routes resolve to `/login`.
+- Backend and frontend automated tests for the logout flow pass.
+- Scope remains limited to explicit logout and does not implement session expiration, idle timeout warnings, or other auth stories.
+
+## Open Blockers Or Follow-Ups
+
+- `US-004 Session Expiration` should own timeout-driven logout behavior and expired-session UX.
+- Auth endpoint rate limiting remains tracked separately under the auth hardening stories.


### PR DESCRIPTION
## Summary
- add backend logout support for the session-based auth flow
- add frontend sign-out actions for both the authenticated shell and reset-required shell
- extend focused auth tests and refine the local `US-003` story into an execution-ready slice

## Notes
- stacked on top of #80 because `US-003` depends on the current auth flow from `US-002`
- keeps session expiration, idle timeout UX, and auth rate limiting out of scope

## Validation
- `pytest tests/integration/test_auth_api.py` -> `23 passed`
- `npm run test:run -- src/features/auth/AuthFlow.test.tsx` -> `12 passed`

## Issue
- refs #8