### PR TITLE
Implement US-004 session expiration

### DIFF
--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -99,6 +99,8 @@ STATIC_ROOT = BASE_DIR / "staticfiles"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 AUTH_USER_MODEL = "users.User"
 AUTHENTICATION_BACKENDS = ["django.contrib.auth.backends.ModelBackend"]
+SESSION_COOKIE_AGE = 28800
+SESSION_SAVE_EVERY_REQUEST = True
 AUTH_PASSWORD_VALIDATORS = [
     {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
     {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},

--- a/backend/tests/integration/test_auth_api.py
+++ b/backend/tests/integration/test_auth_api.py
@@ -1,4 +1,7 @@
+from datetime import timedelta
+
 import pytest
+from django.conf import settings
 from django.test import override_settings
 from django.urls import include, path
 from django.contrib.auth import get_user_model
@@ -333,6 +336,45 @@ def test_current_user_returns_authenticated_profile():
         "is_admin": False,
         "must_reset_password": False,
     }
+
+
+def test_session_timeout_settings_match_the_spec():
+    assert settings.SESSION_COOKIE_AGE == 28800
+    assert settings.SESSION_SAVE_EVERY_REQUEST is True
+
+
+def test_expired_session_is_treated_as_unauthenticated_on_the_next_request():
+    user = create_user(email="expired@example.com")
+    client = APIClient()
+    client.force_login(user)
+
+    session = client.session
+    session.set_expiry(timezone.now() - timedelta(seconds=1))
+    session.save()
+
+    response = client.get("/api/auth/me")
+
+    assert response.status_code == 401
+    assert response.json() == {
+        "error": {
+            "code": "UNAUTHENTICATED",
+            "message": "Authentication required.",
+            "details": {},
+        }
+    }
+
+
+def test_authenticated_requests_refresh_the_session_timeout_cookie():
+    user = create_user(email="rolling-timeout@example.com")
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.get("/api/auth/me")
+
+    assert response.status_code == 200
+    assert "sessionid" in response.cookies
+    assert int(response.cookies["sessionid"]["max-age"]) == settings.SESSION_COOKIE_AGE
+    assert response.cookies["sessionid"]["expires"]
 
 
 @override_settings(ROOT_URLCONF=__name__)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -79,16 +79,17 @@ async function parseResponseBody(response: Response) {
 
 export async function apiRequest<T>(
   path: string,
-  init: RequestInit = {},
+  init: RequestInit & { suppressUnauthorizedHandler?: boolean } = {},
 ): Promise<T> {
+  const { suppressUnauthorizedHandler = false, ...requestInit } = init;
   const headers = new Headers(init.headers);
-  const method = init.method?.toUpperCase() ?? "GET";
+  const method = requestInit.method?.toUpperCase() ?? "GET";
   const isUnsafeMethod = !["GET", "HEAD", "OPTIONS"].includes(method);
   const csrfToken = isUnsafeMethod ? getCsrfToken() : null;
 
   headers.set("Accept", "application/json");
 
-  if (init.body && !headers.has("Content-Type")) {
+  if (requestInit.body && !headers.has("Content-Type")) {
     headers.set("Content-Type", "application/json");
   }
 
@@ -97,7 +98,7 @@ export async function apiRequest<T>(
   }
 
   const response = await fetch(`${API_BASE_URL}${path}`, {
-    ...init,
+    ...requestInit,
     credentials: "include",
     headers,
   });
@@ -107,7 +108,7 @@ export async function apiRequest<T>(
   if (!response.ok) {
     const error = parseApiError(response, payload);
 
-    if (response.status === 401) {
+    if (response.status === 401 && !suppressUnauthorizedHandler) {
       unauthorizedHandler?.();
     }
 

--- a/frontend/src/app/providers/AppProviders.tsx
+++ b/frontend/src/app/providers/AppProviders.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { type PropsWithChildren, useEffect, useState } from "react";
 
 import { registerUnauthorizedHandler } from "../../api/client";
+import { markSessionExpired } from "../../features/auth/state/authUiState";
 import { sessionQueryKey } from "../../features/auth/hooks/useSessionQuery";
 
 function createQueryClient() {
@@ -27,6 +28,7 @@ export function AppProviders({
 
   useEffect(() => {
     registerUnauthorizedHandler(() => {
+      markSessionExpired();
       queryClient.setQueryData(sessionQueryKey, null);
     });
 

--- a/frontend/src/features/auth/AuthFlow.test.tsx
+++ b/frontend/src/features/auth/AuthFlow.test.tsx
@@ -64,9 +64,34 @@ describe("auth flow", () => {
       await screen.findByRole("heading", { name: /session established/i }),
     ).toBeInTheDocument();
     expect(screen.getByText(/jane@example.com/i)).toBeInTheDocument();
+    expect(screen.queryByText(/session expired after inactivity/i)).not.toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledTimes(2);
     const loginRequestHeaders = new Headers(fetchMock.mock.calls[1]?.[1]?.headers);
     expect(loginRequestHeaders.get("X-CSRFToken")).toBe("test-token");
+  });
+
+  it("does not show the expired-session notice during an initial unauthenticated bootstrap", async () => {
+    mockFetchSequence([
+      jsonResponse({
+        status: 401,
+        body: {
+          error: {
+            code: "UNAUTHENTICATED",
+            message: "Authentication required.",
+            details: {},
+          },
+        },
+      }),
+    ]);
+
+    renderApp(["/login"]);
+
+    expect(
+      await screen.findByRole("heading", { name: /user login/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/session expired after inactivity/i),
+    ).not.toBeInTheDocument();
   });
 
   it("redirects to the reset-required shell when login returns a forced reset state", async () => {
@@ -249,6 +274,45 @@ describe("auth flow", () => {
     expect(fetchMock.mock.calls[1]?.[0]).toBe("/api/auth/logout");
     const logoutRequestHeaders = new Headers(fetchMock.mock.calls[1]?.[1]?.headers);
     expect(logoutRequestHeaders.get("X-CSRFToken")).toBe("test-token");
+  });
+
+  it("returns to login with an expired-session message after a later authenticated request gets 401", async () => {
+    mockFetchSequence([
+      jsonResponse({
+        body: {
+          id: "user-1",
+          email: "jane@example.com",
+          name: "Jane Doe",
+          is_admin: false,
+          must_reset_password: false,
+        },
+      }),
+      jsonResponse({
+        status: 401,
+        body: {
+          error: {
+            code: "UNAUTHENTICATED",
+            message: "Authentication required.",
+            details: {},
+          },
+        },
+      }),
+    ]);
+
+    const user = userEvent.setup();
+    renderApp(["/"], { cookie: "csrftoken=test-token; path=/" });
+    await user.click(
+      await screen.findByRole("button", {
+        name: /sign out/i,
+      }),
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: /user login/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/session expired after inactivity\. sign in again to continue\./i),
+    ).toBeInTheDocument();
   });
 
   it("submits a forced password reset and enters the authenticated shell", async () => {

--- a/frontend/src/features/auth/api/authApi.ts
+++ b/frontend/src/features/auth/api/authApi.ts
@@ -53,7 +53,9 @@ export async function logout(): Promise<void> {
 
 export async function fetchSession(): Promise<SessionUser | null> {
   try {
-    const session = await apiRequest<SessionUser>("/auth/me");
+    const session = await apiRequest<SessionUser>("/auth/me", {
+      suppressUnauthorizedHandler: true,
+    });
     return extractSessionUser(session);
   } catch (error) {
     if (isApiError(error) && error.status === 401) {

--- a/frontend/src/features/auth/hooks/useForceResetPasswordMutation.ts
+++ b/frontend/src/features/auth/hooks/useForceResetPasswordMutation.ts
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 
 import { forceResetPassword } from "../api/authApi";
 import { type ForceResetPasswordFormValues } from "../schemas/forceResetPasswordSchema";
+import { clearAuthUiNotice } from "../state/authUiState";
 import { sessionQueryKey } from "./useSessionQuery";
 
 export function useForceResetPasswordMutation() {
@@ -12,6 +13,9 @@ export function useForceResetPasswordMutation() {
   return useMutation({
     mutationFn: ({ new_password }: ForceResetPasswordFormValues) =>
       forceResetPassword({ new_password }),
+    onMutate: () => {
+      clearAuthUiNotice();
+    },
     onSuccess: (session) => {
       queryClient.setQueryData(sessionQueryKey, session);
       navigate(session.must_reset_password ? "/reset-password" : "/");

--- a/frontend/src/features/auth/hooks/useLoginMutation.ts
+++ b/frontend/src/features/auth/hooks/useLoginMutation.ts
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 
 import { login } from "../api/authApi";
 import { type LoginFormValues } from "../schemas/loginSchema";
+import { clearAuthUiNotice } from "../state/authUiState";
 import { sessionQueryKey } from "./useSessionQuery";
 
 export function useLoginMutation() {
@@ -11,6 +12,9 @@ export function useLoginMutation() {
 
   return useMutation({
     mutationFn: (values: LoginFormValues) => login(values),
+    onMutate: () => {
+      clearAuthUiNotice();
+    },
     onSuccess: (session) => {
       queryClient.setQueryData(sessionQueryKey, session);
       navigate(session.must_reset_password ? "/reset-password" : "/");

--- a/frontend/src/features/auth/hooks/useLogoutMutation.ts
+++ b/frontend/src/features/auth/hooks/useLogoutMutation.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 
 import { logout } from "../api/authApi";
+import { clearAuthUiNotice } from "../state/authUiState";
 import { sessionQueryKey } from "./useSessionQuery";
 
 export function useLogoutMutation() {
@@ -11,6 +12,7 @@ export function useLogoutMutation() {
   return useMutation({
     mutationFn: logout,
     onSuccess: () => {
+      clearAuthUiNotice();
       queryClient.setQueryData(sessionQueryKey, null);
       navigate("/login");
     },

--- a/frontend/src/features/auth/pages/LoginPage.tsx
+++ b/frontend/src/features/auth/pages/LoginPage.tsx
@@ -7,6 +7,7 @@ import { Field } from "../../../components/Field";
 import { Panel } from "../../../components/Panel";
 import { StatusMessage } from "../../../components/StatusMessage";
 import { useLoginMutation } from "../hooks/useLoginMutation";
+import { useAuthUiStore } from "../state/authUiState";
 import {
   loginSchema,
   type LoginFormValues,
@@ -15,6 +16,7 @@ import { AuthFrame } from "../components/AuthFrame";
 
 export function LoginPage() {
   const loginMutation = useLoginMutation();
+  const authNotice = useAuthUiStore((state) => state.notice);
   const {
     formState: { errors },
     handleSubmit,
@@ -45,6 +47,11 @@ export function LoginPage() {
             Unauthenticated users are routed here until the session bootstrap succeeds.
           </p>
         </div>
+        {authNotice === "session-expired" ? (
+          <StatusMessage tone="error" title="Session expired">
+            Your session expired after inactivity. Sign in again to continue.
+          </StatusMessage>
+        ) : null}
         <form
           className="form-stack"
           onSubmit={handleSubmit((values) => loginMutation.mutate(values))}

--- a/frontend/src/features/auth/state/authUiState.ts
+++ b/frontend/src/features/auth/state/authUiState.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+
+type AuthUiNotice = "session-expired" | null;
+
+type AuthUiState = {
+  notice: AuthUiNotice;
+  setNotice: (notice: AuthUiNotice) => void;
+  clearNotice: () => void;
+};
+
+export const useAuthUiStore = create<AuthUiState>((set) => ({
+  notice: null,
+  setNotice: (notice) => {
+    set({ notice });
+  },
+  clearNotice: () => {
+    set({ notice: null });
+  },
+}));
+
+export function markSessionExpired() {
+  useAuthUiStore.getState().setNotice("session-expired");
+}
+
+export function clearAuthUiNotice() {
+  useAuthUiStore.getState().clearNotice();
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -2,6 +2,8 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach, vi } from "vitest";
 
+import { clearAuthUiNotice } from "../features/auth/state/authUiState";
+
 Object.assign(globalThis, {
   AbortController: window.AbortController,
   AbortSignal: window.AbortSignal,
@@ -12,6 +14,7 @@ Object.assign(globalThis, {
 
 afterEach(() => {
   cleanup();
+  clearAuthUiNotice();
   document.cookie.split(";").forEach((cookie) => {
     const cookieName = cookie.split("=")[0]?.trim();
     if (cookieName) {

--- a/issues/stories/us-004-session-expiration.md
+++ b/issues/stories/us-004-session-expiration.md
@@ -1,8 +1,21 @@
-﻿# US-004 - Session Expiration  ## Metadata - Area: 1. Authentication and Session Management - GitHub labels: `user-story`, `mvp`, `area:auth` - Suggested status: `Backlog` - Suggested wave: `Wave 1` - Depends on: US-001 - Parallelization note: Start once dependencies are done; run in parallel with other stories in the same wave that do not share blocking dependencies.  ## User Story **As a** user  
+# US-004 - Session Expiration
+
+## Metadata
+
+- Area: 1. Authentication and Session Management
+- GitHub labels: `user-story`, `mvp`, `area:auth`
+- Suggested status: `:owner-review`
+- Suggested wave: `Wave 1`
+- Depends on: `US-001`
+- Builds on implemented auth stack: `US-002`, `US-003`
+
+## User Story
+
+**As a** user  
 **I want** inactive sessions to expire  
 **So that** my account is protected when I stop using the app.
 
-### Acceptance Criteria
+## Acceptance Criteria
 
 **Given** I have been inactive for 8 hours  
 **When** I make another authenticated request  
@@ -10,46 +23,51 @@
 
 **Given** I continue using the application  
 **When** I make authenticated requests  
-**Then** my session inactivity timer is refreshed.  ## Implementation Breakdown **Kanban lane:** Backlog â†’ Ready â†’ Red â†’ Green â†’ Refactor â†’ Review / QA â†’ Done  
-**Definition of Done:** All listed layer tasks are complete, reviewed, tested, and traceable to the story acceptance criteria.
+**Then** my session inactivity timer is refreshed.
 
-### Database
-- [ ] Confirm user fields support auth state: `is_active`, `deleted_at`, `must_reset_password`, `last_login_at`.
-- [ ] Add indexes/constraints required for email uniqueness and active-user lookup.
+## Execution Breakdown
 
-### Backend/API
-- [ ] Implement/validate session endpoint behavior and generic auth errors.
-- [ ] Enforce active, non-deleted user checks before creating sessions.
-- [ ] Add service-level handling for `must_reset_password` and allowed endpoints.
-- [ ] Emit application logs for security-relevant auth events.
+### Backend slice
 
-### Frontend/UI
-- [ ] Build guarded route behavior for authenticated, unauthenticated, and reset-required users.
-- [ ] Display validation, generic credential, expired-session, and rate-limit states.
-- [ ] Attach CSRF tokens and credentials on unsafe requests.
+- [x] Set Django session inactivity settings to match the spec:
+  - `SESSION_COOKIE_AGE = 28800`
+  - `SESSION_SAVE_EVERY_REQUEST = True`
+- [x] Keep expired sessions surfacing through the existing structured unauthenticated behavior instead of introducing a second auth error shape.
+- [x] Leave password-reset enforcement, logout behavior, and rate limiting unchanged in this slice.
 
-### TDD â€” Red: Write Failing Tests First
-- [ ] Map each Given/When/Then acceptance criterion to automated tests.
-- [ ] Add happy-path tests before implementation.
-- [ ] Add validation, permission, and edge-case tests before implementation.
-- [ ] Run the tests and confirm they fail for the expected reason.
-- [ ] Unit test valid/invalid credentials, inactive users, deleted users, and reset-required users.
-- [ ] Integration test full browser/API auth flow and session expiry behavior.
+### Frontend slice
 
-### DevOps/Config
-- [ ] Configure secure cookie settings and rate-limit middleware for production/staging.
+- [x] Keep the existing session bootstrap flow as the source of truth for route guards.
+- [x] Distinguish initial unauthenticated bootstrap from an already-established session expiring during later API activity.
+- [x] When a later authenticated request returns `401`, clear session state and show an expired-session message on the login screen.
+- [x] Do not add remember-me behavior, idle countdown UI, or background polling in this slice.
 
-### TDD â€” Green: Implement Minimum Passing Code
-- [ ] Implement only the smallest database/backend/frontend change needed to pass the failing tests.
-- [ ] Run the story-level test set and confirm all new tests pass.
-- [ ] Confirm existing regression tests still pass.
+### Test slice
 
-### TDD â€” Refactor: Improve Safely
-- [ ] Refactor duplicated logic into services, validators, hooks, or shared components.
-- [ ] Confirm permissions, structured errors, soft-delete behavior, and edge cases remain covered.
-- [ ] Re-run unit, integration, and relevant frontend tests after refactoring.
+- [x] Add backend integration coverage that expired sessions are treated as unauthenticated on the next request.
+- [x] Add backend coverage that authenticated activity refreshes session timeout behavior.
+- [x] Add frontend auth-flow coverage that a post-login `401` returns the user to `/login` with an expired-session message.
+- [x] Re-run the focused auth backend and frontend test suites.
 
-### Review / QA Checklist
-- [ ] Acceptance criteria from the user story are verified manually or by automated tests.
-- [ ] Structured API errors, permissions, and edge cases are validated where applicable.
-- [ ] Documentation or developer notes are updated if behavior is non-obvious.
+## Dependency And Sequencing Notes
+
+- This story depends on the session auth foundation from `US-001`.
+- It should stay stacked on top of the current auth branch chain because the frontend route shell from `US-001` through `US-003` is the surface being updated.
+- This story is intentionally separate from:
+  - `US-003` logout
+  - `US-058` auth endpoint rate limiting
+  - admin user CRUD
+  - project, task, comment, or notification flows
+
+## Definition Of Done
+
+- Django session settings enforce the spec's 8-hour inactivity timeout with refresh-on-use behavior.
+- Expired sessions are treated as unauthenticated without breaking the existing forced-reset and logout flows.
+- The frontend returns users to login after a later authenticated request hits `401` and explains that the session expired.
+- Backend and frontend auth tests cover the new behavior and pass.
+
+## Open Notes
+
+- No additional API endpoint is required for this story.
+- No manual session countdown UI is required for MVP.
+- If future stories need richer auth banners or cross-page session notices, build on the same expired-session state instead of introducing parallel handling paths.

--- a/skills/context/handoffs/2026-05-01-us-004-session-expiration.md
+++ b/skills/context/handoffs/2026-05-01-us-004-session-expiration.md
@@ -1,0 +1,40 @@
+# US-004 Session Expiration
+
+## Scope Landed
+
+- Django session timeout now matches the spec:
+  - `SESSION_COOKIE_AGE = 28800`
+  - `SESSION_SAVE_EVERY_REQUEST = True`
+- Expired sessions continue using the existing structured `UNAUTHENTICATED` response shape.
+- Frontend now distinguishes:
+  - initial anonymous session bootstrap
+  - later `401` responses after an established session
+
+## Reusable Frontend Pattern
+
+- The shared API client now supports `suppressUnauthorizedHandler` for requests that intentionally probe session state.
+- `fetchSession()` uses `suppressUnauthorizedHandler: true` so the initial `/auth/me` bootstrap `401` does not get mislabeled as an expired session.
+- All later `401` responses still flow through the registered unauthorized handler.
+- The handler marks a transient auth UI notice and clears the cached session so routing falls back to `/login`.
+
+## Current Expired-Session UX
+
+- Login shows: `Your session expired after inactivity. Sign in again to continue.`
+- Successful login, logout, and forced reset clear the transient auth notice.
+- No remember-me behavior, countdown timer, or background polling was added.
+
+## Tests Added
+
+- Backend:
+  - session timeout settings match the spec
+  - expired session becomes unauthenticated on next request
+  - authenticated request refreshes the session timeout cookie
+- Frontend:
+  - initial anonymous bootstrap does not show an expired-session notice
+  - later post-login `401` returns to login with the expired-session notice
+
+## Branch Context
+
+- Branch: `us-004-session-expiration`
+- Stack base: `us-003-logout` / PR `#81`
+- Keep the unrelated `.gitignore` change untouched.


### PR DESCRIPTION
## Summary
- configure the Django session timeout to match the 8-hour inactivity spec
- keep initial auth bootstrap separate from later expired-session handling in the shared frontend auth shell
- add focused backend and frontend auth tests for session expiry and rolling refresh behavior

## Validation
- `pytest tests/integration/test_auth_api.py` -> `26 passed`
- `npm run test:run -- src/features/auth/AuthFlow.test.tsx` -> `14 passed`

## Notes
- stacked on top of `#81` because `US-004` builds on the current auth branch chain
- leaves the unrelated local `.gitignore` change out of the PR

refs #9