### PR TITLE
Implement US-005 create user

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ This repository is planning-first. Agents working here should treat the Markdown
 12. Keep the local `issues/` backlog and GitHub issues in sync using `issues/sync-policy.md`.
 13. Use `issues/github-label-policy.md` for the active GitHub label names.
 14. Agents may mark work as implemented or owner-review, but only the repository owner may mark work done or reviewed.
+15. After finishing an issue implementation slice and syncing its issue state, agents should create the corresponding PR in the same pass unless the owner explicitly says not to.
 
 ## Specialist Roles
 

--- a/backend/apps/users/api/permissions.py
+++ b/backend/apps/users/api/permissions.py
@@ -14,3 +14,22 @@ class IsAuthenticatedAndPasswordResetComplete(BasePermission):
             return False
 
         return not user.must_reset_password
+
+
+class IsAdminUser(BasePermission):
+    message = "Admin access required."
+
+    def has_permission(self, request, view) -> bool:
+        user = request.user
+
+        if not user or not user.is_authenticated:
+            return False
+
+        if not user.is_active or user.deleted_at is not None:
+            return False
+
+        if user.must_reset_password:
+            self.message = "Password reset required."
+            return False
+
+        return bool(user.is_admin)

--- a/backend/apps/users/api/serializers.py
+++ b/backend/apps/users/api/serializers.py
@@ -10,9 +10,25 @@ class ForceResetPasswordSerializer(serializers.Serializer):
     new_password = serializers.CharField(trim_whitespace=False)
 
 
+class CreateUserSerializer(serializers.Serializer):
+    name = serializers.CharField(max_length=255)
+    email = serializers.EmailField()
+    temporary_password = serializers.CharField(trim_whitespace=False)
+    is_active = serializers.BooleanField(required=False, default=True)
+
+
 class SessionUserSerializer(serializers.Serializer):
     id = serializers.UUIDField(format="hex_verbose")
     email = serializers.EmailField()
     name = serializers.CharField()
+    is_admin = serializers.BooleanField()
+    must_reset_password = serializers.BooleanField()
+
+
+class AdminUserSerializer(serializers.Serializer):
+    id = serializers.UUIDField(format="hex_verbose")
+    email = serializers.EmailField()
+    name = serializers.CharField()
+    is_active = serializers.BooleanField()
     is_admin = serializers.BooleanField()
     must_reset_password = serializers.BooleanField()

--- a/backend/apps/users/api/urls.py
+++ b/backend/apps/users/api/urls.py
@@ -1,8 +1,15 @@
 from django.urls import path
 
-from .views import CurrentUserView, ForceResetPasswordView, LoginView, LogoutView
+from .views import (
+    AdminUserListCreateView,
+    CurrentUserView,
+    ForceResetPasswordView,
+    LoginView,
+    LogoutView,
+)
 
 urlpatterns = [
+    path("admin/users", AdminUserListCreateView.as_view(), name="admin-users"),
     path("auth/login", LoginView.as_view(), name="auth-login"),
     path("auth/logout", LogoutView.as_view(), name="auth-logout"),
     path("auth/me", CurrentUserView.as_view(), name="auth-me"),

--- a/backend/apps/users/api/views.py
+++ b/backend/apps/users/api/views.py
@@ -6,6 +6,8 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.users.domain.services import (
+    create_user_account,
+    DuplicateEmailError,
     InvalidCredentialsError,
     authenticate_user_session,
     force_reset_password,
@@ -17,10 +19,13 @@ from apps.users.domain.services import (
 )
 
 from .serializers import (
+    AdminUserSerializer,
+    CreateUserSerializer,
     ForceResetPasswordSerializer,
     LoginSerializer,
     SessionUserSerializer,
 )
+from .permissions import IsAdminUser
 
 
 def error_response(*, code: str, message: str, details: dict, status_code: int) -> Response:
@@ -169,3 +174,44 @@ class LogoutView(APIView):
             )
 
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+@method_decorator(csrf_protect, name="dispatch")
+class AdminUserListCreateView(APIView):
+    permission_classes = [IsAdminUser]
+
+    def post(self, request):
+        serializer = CreateUserSerializer(data=request.data)
+        if not serializer.is_valid():
+            return error_response(
+                code="VALIDATION_ERROR",
+                message="Invalid input",
+                details=serializer.errors,
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            created_user = create_user_account(
+                actor=request.user,
+                name=serializer.validated_data["name"],
+                email=serializer.validated_data["email"],
+                temporary_password=serializer.validated_data["temporary_password"],
+                is_active=serializer.validated_data["is_active"],
+            )
+        except DuplicateEmailError:
+            return error_response(
+                code="VALIDATION_ERROR",
+                message="Invalid input",
+                details={"email": ["A user with this email already exists."]},
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+        except PasswordValidationFailedError as exc:
+            return error_response(
+                code="VALIDATION_ERROR",
+                message="Invalid input",
+                details=exc.details,
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+
+        user_data = AdminUserSerializer(created_user).data
+        return Response({"user": user_data}, status=status.HTTP_201_CREATED)

--- a/backend/apps/users/domain/services.py
+++ b/backend/apps/users/domain/services.py
@@ -32,6 +32,10 @@ class PasswordValidationFailedError(Exception):
         self.details = details
 
 
+class DuplicateEmailError(Exception):
+    pass
+
+
 @dataclass(frozen=True)
 class AuthenticatedSession:
     user: object
@@ -77,7 +81,7 @@ def logout_user_session(*, request) -> bool:
     return True
 
 
-def validate_user_password(*, user, password: str) -> None:
+def validate_user_password(*, user, password: str, field_name: str = "new_password") -> None:
     try:
         if getattr(settings, "AUTH_PASSWORD_VALIDATORS", None):
             validate_password(password, user=user)
@@ -88,7 +92,40 @@ def validate_user_password(*, user, password: str) -> None:
                 password_validators=DEFAULT_PASSWORD_VALIDATORS,
             )
     except ValidationError as exc:
-        raise PasswordValidationFailedError({"new_password": exc.messages}) from exc
+        raise PasswordValidationFailedError({field_name: exc.messages}) from exc
+
+
+@transaction.atomic
+def create_user_account(*, actor, name: str, email: str, temporary_password: str, is_active: bool = True):
+    user_model = get_user_model()
+    normalized_email = user_model.objects.normalize_email(email).lower()
+
+    if user_model.all_objects.filter(email__iexact=normalized_email).exists():
+        raise DuplicateEmailError
+
+    provisional_user = user_model(
+        email=normalized_email,
+        name=name,
+        is_active=is_active,
+        is_admin=False,
+        must_reset_password=True,
+    )
+    validate_user_password(
+        user=provisional_user,
+        password=temporary_password,
+        field_name="temporary_password",
+    )
+
+    created_user = user_model.all_objects.create_user(
+        email=normalized_email,
+        password=temporary_password,
+        name=name,
+        is_active=is_active,
+        is_admin=False,
+        must_reset_password=True,
+    )
+
+    return created_user
 
 
 @transaction.atomic

--- a/backend/tests/integration/test_auth_api.py
+++ b/backend/tests/integration/test_auth_api.py
@@ -377,6 +377,137 @@ def test_authenticated_requests_refresh_the_session_timeout_cookie():
     assert response.cookies["sessionid"]["expires"]
 
 
+def test_admin_can_create_a_user_with_a_temporary_password():
+    admin_user = create_user(
+        email="admin@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    client = APIClient()
+    client.force_login(admin_user)
+
+    response = client.post(
+        "/api/admin/users",
+        {
+            "name": "New User",
+            "email": "new.user@example.com",
+            "temporary_password": "TempPassword123!",
+            "is_active": True,
+        },
+        format="json",
+    )
+
+    created_user = get_user_model().all_objects.get(email="new.user@example.com")
+
+    assert response.status_code == 201
+    assert response.json() == {
+        "user": {
+            "id": str(created_user.id),
+            "email": "new.user@example.com",
+            "name": "New User",
+            "is_active": True,
+            "is_admin": False,
+            "must_reset_password": True,
+        }
+    }
+    assert created_user.is_active is True
+    assert created_user.is_admin is False
+    assert created_user.must_reset_password is True
+    assert created_user.check_password("TempPassword123!") is True
+    assert created_user.password != "TempPassword123!"
+
+
+def test_create_user_rejects_duplicate_email_with_a_validation_error():
+    admin_user = create_user(
+        email="admin.duplicate@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    create_user(email="existing@example.com")
+    client = APIClient()
+    client.force_login(admin_user)
+
+    response = client.post(
+        "/api/admin/users",
+        {
+            "name": "Existing Clone",
+            "email": "existing@example.com",
+            "temporary_password": "TempPassword123!",
+            "is_active": True,
+        },
+        format="json",
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": {
+            "code": "VALIDATION_ERROR",
+            "message": "Invalid input",
+            "details": {
+                "email": ["A user with this email already exists."],
+            },
+        }
+    }
+
+
+def test_create_user_denies_non_admin_users():
+    standard_user = create_user(
+        email="member@example.com",
+        is_admin=False,
+        must_reset_password=False,
+    )
+    client = APIClient()
+    client.force_login(standard_user)
+
+    response = client.post(
+        "/api/admin/users",
+        {
+            "name": "Denied User",
+            "email": "denied@example.com",
+            "temporary_password": "TempPassword123!",
+        },
+        format="json",
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Admin access required."}
+
+
+def test_create_user_validates_the_temporary_password_against_the_password_policy():
+    admin_user = create_user(
+        email="admin.password@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    client = APIClient()
+    client.force_login(admin_user)
+
+    response = client.post(
+        "/api/admin/users",
+        {
+            "name": "Weak Password User",
+            "email": "weak.password@example.com",
+            "temporary_password": "short",
+            "is_active": True,
+        },
+        format="json",
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": {
+            "code": "VALIDATION_ERROR",
+            "message": "Invalid input",
+            "details": {
+                "temporary_password": [
+                    "This password is too short. It must contain at least 8 characters."
+                ]
+            },
+        }
+    }
+    assert get_user_model().all_objects.filter(email="weak.password@example.com").exists() is False
+
+
 @override_settings(ROOT_URLCONF=__name__)
 def test_reset_required_user_is_blocked_from_protected_endpoints():
     user = create_user(email="blocked@example.com", must_reset_password=True)

--- a/issues/stories/us-005-create-user.md
+++ b/issues/stories/us-005-create-user.md
@@ -1,8 +1,21 @@
-﻿# US-005 - Create User  ## Metadata - Area: 2. Admin User Management - GitHub labels: `user-story`, `mvp`, `area:admin` - Suggested status: `Backlog` - Suggested wave: `Wave 0` - Depends on: US-001 - Parallelization note: Start once dependencies are done; run in parallel with other stories in the same wave that do not share blocking dependencies.  ## User Story **As an** Admin  
+# US-005 - Create User
+
+## Metadata
+
+- Area: 2. Admin User Management
+- GitHub labels: `user-story`, `mvp`, `area:admin`
+- Suggested status: `:owner-review`
+- Suggested wave: `Wave 0`
+- Depends on: `US-001`
+- Builds on auth stack through: `US-004`
+
+## User Story
+
+**As an** Admin  
 **I want** to create user accounts  
 **So that** employees can access the system.
 
-### Acceptance Criteria
+## Acceptance Criteria
 
 **Given** I am an Admin  
 **When** I create a user with name, unique email, and valid temporary password  
@@ -14,43 +27,56 @@
 
 **Given** I am not an Admin  
 **When** I attempt to create a user  
-**Then** the system denies permission.  ## Implementation Breakdown **Kanban lane:** Backlog â†’ Ready â†’ Red â†’ Green â†’ Refactor â†’ Review / QA â†’ Done  
-**Definition of Done:** All listed layer tasks are complete, reviewed, tested, and traceable to the story acceptance criteria.
+**Then** the system denies permission.
 
-### Database
-- [ ] Create/update user schema with UUID primary key, unique email, active flag, admin flag, reset flag, timestamps, soft delete.
-- [ ] Add migration and database constraints for required user fields.
+## Execution Breakdown
 
-### Backend/API
-- [ ] Implement admin-only user endpoint/service logic.
-- [ ] Validate email uniqueness and password policy where relevant.
-- [ ] Apply soft-delete/deactivation rules without cascading assignment deletion.
-- [ ] Create activity/application logs for user management events.
+### Backend slice
 
-### Frontend/UI
-- [ ] Build admin user management form/table action states.
-- [ ] Show success/error feedback for create, update, deactivate, and reset operations.
+- [x] Add an admin-only create-user API endpoint in the `users` module.
+- [x] Keep request validation transport-level and user-creation rules in a domain service.
+- [x] Create the user with:
+  - normalized unique email
+  - active account by default
+  - `must_reset_password = true`
+  - password hashed through Django user APIs
+- [x] Reuse the existing password validation path so admin-set temporary passwords follow the same policy.
+- [x] Return a stable response payload with the created user's public fields needed for future admin UI work.
+- [x] Deny access for non-admin authenticated users.
 
-### TDD â€” Red: Write Failing Tests First
-- [ ] Map each Given/When/Then acceptance criterion to automated tests.
-- [ ] Add happy-path tests before implementation.
-- [ ] Add validation, permission, and edge-case tests before implementation.
-- [ ] Run the tests and confirm they fail for the expected reason.
-- [ ] Permission tests for admin-only access.
-- [ ] Integration tests for user create/update/deactivate/reset flows.
-- [ ] Regression tests that inactive/deleted users cannot log in.
+### Frontend slice
 
-### TDD â€” Green: Implement Minimum Passing Code
-- [ ] Implement only the smallest database/backend/frontend change needed to pass the failing tests.
-- [ ] Run the story-level test set and confirm all new tests pass.
-- [ ] Confirm existing regression tests still pass.
+- [x] No dedicated admin UI in this slice.
+- [x] Defer admin screens and routes until there is an owned admin feature surface to attach them to.
+- [x] Keep the backend response contract explicit so a later admin UI story can integrate without revisiting create-user rules.
 
-### TDD â€” Refactor: Improve Safely
-- [ ] Refactor duplicated logic into services, validators, hooks, or shared components.
-- [ ] Confirm permissions, structured errors, soft-delete behavior, and edge cases remain covered.
-- [ ] Re-run unit, integration, and relevant frontend tests after refactoring.
+### Test slice
 
-### Review / QA Checklist
-- [ ] Acceptance criteria from the user story are verified manually or by automated tests.
-- [ ] Structured API errors, permissions, and edge cases are validated where applicable.
-- [ ] Documentation or developer notes are updated if behavior is non-obvious.
+- [x] Add backend integration coverage for successful admin user creation.
+- [x] Add backend coverage for duplicate-email validation.
+- [x] Add backend coverage for non-admin permission denial.
+- [x] Add backend coverage that the stored password is hashed and the created user must reset their password.
+- [x] Re-run the focused auth and user-management backend tests.
+
+## Dependency And Sequencing Notes
+
+- This story depends on the existing session-auth stack so admin identity is available server-side.
+- It should remain separate from:
+  - `US-006` update user
+  - `US-007` admin password reset
+  - `US-008` deactivate user
+  - broader admin list/detail UI work
+- The first valid slice is backend-led because the current frontend only exposes auth/system routing, not an admin workspace.
+
+## Definition Of Done
+
+- Admins can create users through the API with name, email, and temporary password.
+- New users are active and created with `must_reset_password = true`.
+- Duplicate emails return a structured validation error.
+- Non-admins cannot create users.
+- Backend tests cover the acceptance criteria and pass.
+
+## Open Notes
+
+- Activity logging for `USER_CREATED` is part of the broader observability/audit surface and can follow once that module exists.
+- This slice should not invent admin tables, forms, or navigation before the admin feature surface is introduced.

--- a/skills/context/handoffs/2026-05-01-us-005-create-user.md
+++ b/skills/context/handoffs/2026-05-01-us-005-create-user.md
@@ -1,0 +1,44 @@
+# US-005 Create User
+
+## Scope Landed
+
+- Added `POST /api/admin/users` in the `users` module.
+- Delivery is intentionally backend-only for this story slice because the app still has no owned admin route surface.
+- The endpoint returns a stable created-user payload:
+  - `id`
+  - `email`
+  - `name`
+  - `is_active`
+  - `is_admin`
+  - `must_reset_password`
+
+## Domain Rules
+
+- Only admins may create users.
+- New users are created with:
+  - normalized lowercase email
+  - hashed password
+  - `must_reset_password = true`
+  - `is_admin = false`
+- `is_active` defaults to `true` unless explicitly supplied otherwise.
+
+## Reusable Backend Pattern
+
+- The shared `validate_user_password()` helper in `apps.users.domain.services` now accepts a `field_name`.
+- Forced-reset still reports password-policy errors on `new_password`.
+- Admin create-user reports password-policy errors on `temporary_password`.
+- Duplicate email handling stays in the domain service and is mapped back to a structured `VALIDATION_ERROR` envelope in the API view.
+
+## Tests Added
+
+- admin can create a user with a temporary password
+- duplicate email returns a structured validation error
+- non-admin users are denied
+- temporary password is validated against the password policy
+
+## Branch Context
+
+- Branch: `us-005-create-user`
+- Stack base: `us-004-session-expiration` / PR `#82`
+- Keep the unrelated `.gitignore` change untouched.
+- Keep the older untracked `2026-05-01-auth-story-stack-through-us-003.md` note out of future PRs unless it is intentionally added.


### PR DESCRIPTION
## Summary
- add the admin-only create-user endpoint in the users module
- create users through a domain service with normalized email, hashed temporary password, and forced reset state
- cover success, duplicate-email validation, non-admin denial, and password-policy enforcement with backend integration tests
- update `AGENTS.md` so future issue completions open their PR in the same pass by default

## Validation
- `pytest tests/integration/test_auth_api.py` -> `30 passed`

## Notes
- stacked on top of `#82` because `US-005` builds on the current auth branch chain
- intentionally backend-only because the repo still has no owned admin frontend workspace
- leaves the unrelated local `.gitignore` change out of the PR

refs #10