### PR TITLE
Implement US-006 update user

### DIFF
--- a/backend/apps/users/api/serializers.py
+++ b/backend/apps/users/api/serializers.py
@@ -17,6 +17,35 @@ class CreateUserSerializer(serializers.Serializer):
     is_active = serializers.BooleanField(required=False, default=True)
 
 
+class UpdateUserSerializer(serializers.Serializer):
+    name = serializers.CharField(max_length=255, required=False)
+    email = serializers.EmailField(required=False)
+    is_active = serializers.BooleanField(required=False)
+
+    def validate(self, attrs):
+        allowed_fields = {"name", "email", "is_active"}
+        unsupported_fields = sorted(set(self.initial_data.keys()) - allowed_fields)
+
+        if unsupported_fields:
+            raise serializers.ValidationError(
+                {
+                    field: ["This field is not supported."]
+                    for field in unsupported_fields
+                }
+            )
+
+        if not attrs:
+            raise serializers.ValidationError(
+                {
+                    "non_field_errors": [
+                        "At least one supported field must be provided."
+                    ]
+                }
+            )
+
+        return attrs
+
+
 class SessionUserSerializer(serializers.Serializer):
     id = serializers.UUIDField(format="hex_verbose")
     email = serializers.EmailField()

--- a/backend/apps/users/api/urls.py
+++ b/backend/apps/users/api/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from .views import (
+    AdminUserDetailView,
     AdminUserListCreateView,
     CurrentUserView,
     ForceResetPasswordView,
@@ -10,6 +11,7 @@ from .views import (
 
 urlpatterns = [
     path("admin/users", AdminUserListCreateView.as_view(), name="admin-users"),
+    path("admin/users/<uuid:user_id>", AdminUserDetailView.as_view(), name="admin-user-detail"),
     path("auth/login", LoginView.as_view(), name="auth-login"),
     path("auth/logout", LogoutView.as_view(), name="auth-logout"),
     path("auth/me", CurrentUserView.as_view(), name="auth-me"),

--- a/backend/apps/users/api/views.py
+++ b/backend/apps/users/api/views.py
@@ -16,6 +16,8 @@ from apps.users.domain.services import (
     PasswordResetNotRequiredError,
     PasswordValidationFailedError,
     serialize_session_user,
+    update_user_account,
+    UserNotFoundError,
 )
 
 from .serializers import (
@@ -24,6 +26,7 @@ from .serializers import (
     ForceResetPasswordSerializer,
     LoginSerializer,
     SessionUserSerializer,
+    UpdateUserSerializer,
 )
 from .permissions import IsAdminUser
 
@@ -215,3 +218,42 @@ class AdminUserListCreateView(APIView):
 
         user_data = AdminUserSerializer(created_user).data
         return Response({"user": user_data}, status=status.HTTP_201_CREATED)
+
+
+@method_decorator(csrf_protect, name="dispatch")
+class AdminUserDetailView(APIView):
+    permission_classes = [IsAdminUser]
+
+    def patch(self, request, user_id):
+        serializer = UpdateUserSerializer(data=request.data)
+        if not serializer.is_valid():
+            return error_response(
+                code="VALIDATION_ERROR",
+                message="Invalid input",
+                details=serializer.errors,
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            updated_user = update_user_account(
+                actor=request.user,
+                user_id=user_id,
+                **serializer.validated_data,
+            )
+        except UserNotFoundError:
+            return error_response(
+                code="USER_NOT_FOUND",
+                message="User not found.",
+                details={},
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
+        except DuplicateEmailError:
+            return error_response(
+                code="VALIDATION_ERROR",
+                message="Invalid input",
+                details={"email": ["A user with this email already exists."]},
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+
+        user_data = AdminUserSerializer(updated_user).data
+        return Response({"user": user_data}, status=status.HTTP_200_OK)

--- a/backend/apps/users/domain/services.py
+++ b/backend/apps/users/domain/services.py
@@ -36,6 +36,10 @@ class DuplicateEmailError(Exception):
     pass
 
 
+class UserNotFoundError(Exception):
+    pass
+
+
 @dataclass(frozen=True)
 class AuthenticatedSession:
     user: object
@@ -126,6 +130,49 @@ def create_user_account(*, actor, name: str, email: str, temporary_password: str
     )
 
     return created_user
+
+
+@transaction.atomic
+def update_user_account(
+    *,
+    actor,
+    user_id,
+    name=None,
+    email=None,
+    is_active=None,
+):
+    user_model = get_user_model()
+    user = (
+        user_model.all_objects.select_for_update()
+        .filter(pk=user_id, deleted_at__isnull=True)
+        .first()
+    )
+
+    if user is None:
+        raise UserNotFoundError
+
+    update_fields = []
+
+    if name is not None:
+        user.name = name
+        update_fields.append("name")
+
+    if email is not None:
+        normalized_email = user_model.objects.normalize_email(email).lower()
+        if user_model.all_objects.filter(email__iexact=normalized_email).exclude(pk=user.pk).exists():
+            raise DuplicateEmailError
+
+        user.email = normalized_email
+        update_fields.append("email")
+
+    if is_active is not None:
+        user.is_active = is_active
+        update_fields.append("is_active")
+
+    if update_fields:
+        user.save(update_fields=[*update_fields, "updated_at"])
+
+    return user
 
 
 @transaction.atomic

--- a/backend/tests/integration/test_auth_api.py
+++ b/backend/tests/integration/test_auth_api.py
@@ -508,6 +508,198 @@ def test_create_user_validates_the_temporary_password_against_the_password_polic
     assert get_user_model().all_objects.filter(email="weak.password@example.com").exists() is False
 
 
+def test_admin_can_update_name_email_and_active_status_for_an_existing_user():
+    admin_user = create_user(
+        email="admin.update@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    managed_user = create_user(email="person.before@example.com", name="Before Name")
+    client = APIClient()
+    client.force_login(admin_user)
+
+    response = client.patch(
+        f"/api/admin/users/{managed_user.id}",
+        {
+            "name": "After Name",
+            "email": "person.after@example.com",
+            "is_active": False,
+        },
+        format="json",
+    )
+
+    managed_user.refresh_from_db()
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "user": {
+            "id": str(managed_user.id),
+            "email": "person.after@example.com",
+            "name": "After Name",
+            "is_active": False,
+            "is_admin": False,
+            "must_reset_password": False,
+        }
+    }
+    assert managed_user.name == "After Name"
+    assert managed_user.email == "person.after@example.com"
+    assert managed_user.is_active is False
+
+
+def test_update_user_rejects_duplicate_email_with_a_validation_error():
+    admin_user = create_user(
+        email="admin.update-duplicate@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    create_user(email="existing.update@example.com")
+    managed_user = create_user(email="change.me@example.com", name="Change Me")
+    client = APIClient()
+    client.force_login(admin_user)
+
+    response = client.patch(
+        f"/api/admin/users/{managed_user.id}",
+        {"email": "existing.update@example.com"},
+        format="json",
+    )
+
+    managed_user.refresh_from_db()
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": {
+            "code": "VALIDATION_ERROR",
+            "message": "Invalid input",
+            "details": {
+                "email": ["A user with this email already exists."],
+            },
+        }
+    }
+    assert managed_user.email == "change.me@example.com"
+
+
+def test_update_user_rejects_unsupported_fields_without_mutating_the_user():
+    admin_user = create_user(
+        email="admin.unsupported@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    managed_user = create_user(email="unsupported.target@example.com", name="Supported Name")
+    client = APIClient()
+    client.force_login(admin_user)
+
+    response = client.patch(
+        f"/api/admin/users/{managed_user.id}",
+        {
+            "is_admin": True,
+            "must_reset_password": True,
+        },
+        format="json",
+    )
+
+    managed_user.refresh_from_db()
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": {
+            "code": "VALIDATION_ERROR",
+            "message": "Invalid input",
+            "details": {
+                "is_admin": ["This field is not supported."],
+                "must_reset_password": ["This field is not supported."],
+            },
+        }
+    }
+    assert managed_user.is_admin is False
+    assert managed_user.must_reset_password is False
+
+
+def test_update_user_denies_non_admin_users():
+    standard_user = create_user(
+        email="member.update@example.com",
+        is_admin=False,
+        must_reset_password=False,
+    )
+    managed_user = create_user(email="managed.member@example.com")
+    client = APIClient()
+    client.force_login(standard_user)
+
+    response = client.patch(
+        f"/api/admin/users/{managed_user.id}",
+        {"name": "Denied Update"},
+        format="json",
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Admin access required."}
+
+
+def test_update_user_returns_not_found_for_soft_deleted_users():
+    admin_user = create_user(
+        email="admin.soft-delete@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    managed_user = create_user(
+        email="soft.deleted@example.com",
+        deleted_at=timezone.now(),
+    )
+    client = APIClient()
+    client.force_login(admin_user)
+
+    response = client.patch(
+        f"/api/admin/users/{managed_user.id}",
+        {"name": "Should Not Apply"},
+        format="json",
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": {
+            "code": "USER_NOT_FOUND",
+            "message": "User not found.",
+            "details": {},
+        }
+    }
+
+
+def test_deactivated_users_cannot_log_in_after_an_admin_deactivates_them():
+    admin_user = create_user(
+        email="admin.deactivate@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    managed_user = create_user(email="deactivated.later@example.com")
+    admin_client = APIClient()
+    admin_client.force_login(admin_user)
+
+    update_response = admin_client.patch(
+        f"/api/admin/users/{managed_user.id}",
+        {"is_active": False},
+        format="json",
+    )
+
+    login_client = APIClient()
+    login_response = login_client.post(
+        "/api/auth/login",
+        {"email": managed_user.email, "password": "valid-password"},
+        format="json",
+    )
+
+    managed_user.refresh_from_db()
+
+    assert update_response.status_code == 200
+    assert managed_user.is_active is False
+    assert login_response.status_code == 401
+    assert login_response.json() == {
+        "error": {
+            "code": "INVALID_CREDENTIALS",
+            "message": "Invalid email or password.",
+            "details": {},
+        }
+    }
+
+
 @override_settings(ROOT_URLCONF=__name__)
 def test_reset_required_user_is_blocked_from_protected_endpoints():
     user = create_user(email="blocked@example.com", must_reset_password=True)

--- a/issues/stories/us-006-update-user.md
+++ b/issues/stories/us-006-update-user.md
@@ -1,8 +1,21 @@
-﻿# US-006 - Update User  ## Metadata - Area: 2. Admin User Management - GitHub labels: `user-story`, `mvp`, `area:admin` - Suggested status: `Backlog` - Suggested wave: `Wave 1` - Depends on: US-005 - Parallelization note: Start once dependencies are done; run in parallel with other stories in the same wave that do not share blocking dependencies.  ## User Story **As an** Admin  
+# US-006 - Update User
+
+## Metadata
+
+- Area: 2. Admin User Management
+- GitHub labels: `user-story`, `mvp`, `area:admin`
+- Suggested status: `Ready`
+- Suggested wave: `Wave 1`
+- Depends on: `US-005`
+- Parallelization note: Start after `US-005` because this story extends the same admin user API surface.
+
+## User Story
+
+**As an** Admin  
 **I want** to update user profile and active status  
 **So that** user records remain accurate.
 
-### Acceptance Criteria
+## Acceptance Criteria
 
 **Given** I am an Admin  
 **When** I update a user name, email, or active status  
@@ -10,43 +23,51 @@
 
 **Given** I attempt to update unsupported fields  
 **When** I submit the request  
-**Then** the system rejects unsupported changes.  ## Implementation Breakdown **Kanban lane:** Backlog â†’ Ready â†’ Red â†’ Green â†’ Refactor â†’ Review / QA â†’ Done  
-**Definition of Done:** All listed layer tasks are complete, reviewed, tested, and traceable to the story acceptance criteria.
+**Then** the system rejects unsupported changes.
 
-### Database
-- [ ] Create/update user schema with UUID primary key, unique email, active flag, admin flag, reset flag, timestamps, soft delete.
-- [ ] Add migration and database constraints for required user fields.
+## Execution Breakdown
 
-### Backend/API
-- [ ] Implement admin-only user endpoint/service logic.
-- [ ] Validate email uniqueness and password policy where relevant.
-- [ ] Apply soft-delete/deactivation rules without cascading assignment deletion.
-- [ ] Create activity/application logs for user management events.
+### Backend Slice
 
-### Frontend/UI
-- [ ] Build admin user management form/table action states.
-- [ ] Show success/error feedback for create, update, deactivate, and reset operations.
+- [x] Add admin-only `PATCH /api/admin/users/{user_id}` under the owning `users` module.
+- [x] Support partial updates for only:
+  - `name`
+  - `email`
+  - `is_active`
+- [x] Normalize updated email to lowercase before persistence.
+- [x] Reject duplicate email values across active and soft-deleted users.
+- [x] Return the same admin-user payload shape already used by `POST /api/admin/users`.
+- [x] Keep update rules in `apps/users/domain/services.py` and keep the view thin.
+- [x] Treat soft-deleted or missing users as not found.
 
-### TDD â€” Red: Write Failing Tests First
-- [ ] Map each Given/When/Then acceptance criterion to automated tests.
-- [ ] Add happy-path tests before implementation.
-- [ ] Add validation, permission, and edge-case tests before implementation.
-- [ ] Run the tests and confirm they fail for the expected reason.
-- [ ] Permission tests for admin-only access.
-- [ ] Integration tests for user create/update/deactivate/reset flows.
-- [ ] Regression tests that inactive/deleted users cannot log in.
+### Frontend Slice
 
-### TDD â€” Green: Implement Minimum Passing Code
-- [ ] Implement only the smallest database/backend/frontend change needed to pass the failing tests.
-- [ ] Run the story-level test set and confirm all new tests pass.
-- [ ] Confirm existing regression tests still pass.
+- [x] No frontend implementation in this slice.
+- [x] Keep the story backend-only until the admin user-management UI has an owned route surface.
 
-### TDD â€” Refactor: Improve Safely
-- [ ] Refactor duplicated logic into services, validators, hooks, or shared components.
-- [ ] Confirm permissions, structured errors, soft-delete behavior, and edge cases remain covered.
-- [ ] Re-run unit, integration, and relevant frontend tests after refactoring.
+### Test Slice
 
-### Review / QA Checklist
-- [ ] Acceptance criteria from the user story are verified manually or by automated tests.
-- [ ] Structured API errors, permissions, and edge cases are validated where applicable.
-- [ ] Documentation or developer notes are updated if behavior is non-obvious.
+- [x] Add integration coverage for successful admin updates of `name`, `email`, and `is_active`.
+- [x] Add integration coverage for duplicate-email rejection.
+- [x] Add integration coverage for unsupported-field rejection such as `is_admin` or `must_reset_password`.
+- [x] Add permission coverage showing non-admin users cannot update users.
+- [x] Add regression coverage showing deactivated users still cannot log in after an admin toggles `is_active` to `false`.
+
+## Dependencies And Notes
+
+- `US-005` already established the admin-only create-user surface and reusable admin-user serializer payload. Reuse that contract instead of creating a second response shape.
+- This story should not implement:
+  - admin password reset
+  - soft delete / deactivate endpoint semantics from `US-008`
+  - admin list or detail read endpoints
+  - admin UI
+- Unsupported-field rejection should come from the update serializer contract, not ad hoc view branching.
+
+## Definition Of Done
+
+- `PATCH /api/admin/users/{user_id}` exists and is admin-only.
+- Only `name`, `email`, and `is_active` are writable.
+- Duplicate emails return a structured `VALIDATION_ERROR`.
+- Unsupported fields are rejected and do not mutate the user.
+- Soft-deleted users cannot be updated through this endpoint.
+- Integration tests cover the acceptance criteria, permissions, and inactive-login regression.

--- a/skills/context/handoffs/2026-05-01-us-006-update-user.md
+++ b/skills/context/handoffs/2026-05-01-us-006-update-user.md
@@ -1,0 +1,40 @@
+# US-006 Update User
+
+## Scope Landed
+
+- Added admin-only `PATCH /api/admin/users/{user_id}` in the `users` module.
+- Delivery is intentionally backend-only for this story slice because the app still has no owned admin user-management UI route surface.
+- The endpoint reuses the same admin-user response payload returned by `POST /api/admin/users`.
+
+## Domain Rules
+
+- Only admins may update users through this endpoint.
+- Only these fields are writable:
+  - `name`
+  - `email`
+  - `is_active`
+- Updated email values are normalized to lowercase before saving.
+- Duplicate emails are rejected across active and soft-deleted users.
+- Soft-deleted users are treated as not found for update operations.
+
+## Reusable Backend Pattern
+
+- `UpdateUserSerializer` explicitly rejects unsupported input fields instead of silently ignoring them.
+- `update_user_account()` owns normalization, duplicate-email checks, record lookup, and persistence.
+- Admin create and update now share the same `AdminUserSerializer` payload, which keeps the admin-user write surface consistent while list/detail read endpoints do not exist yet.
+
+## Tests Added
+
+- admin can update `name`, `email`, and `is_active`
+- duplicate email returns a structured validation error
+- unsupported fields are rejected without mutating the user
+- non-admin users are denied
+- soft-deleted targets return not found
+- deactivated users still cannot log in after the admin update
+
+## Branch Context
+
+- Branch: `us-006-update-user`
+- Stack base: `us-005-create-user` / PR `#83`
+- Keep the unrelated `.gitignore` change untouched.
+- Keep the older untracked `2026-05-01-auth-story-stack-through-us-003.md` note out of future PRs unless it is intentionally added.


### PR DESCRIPTION
## Summary
- add admin-only `PATCH /api/admin/users/{user_id}` in the `users` module
- allow partial updates for `name`, `email`, and `is_active` only
- add integration coverage for duplicate email, unsupported fields, permissions, soft-deleted targets, and deactivated-login regression

## Validation
- `backend\\.venv\\Scripts\\python.exe -m pytest tests/integration/test_auth_api.py`