### PR TITLE
Implement US-007 reset user password

### DIFF
--- a/backend/apps/users/api/serializers.py
+++ b/backend/apps/users/api/serializers.py
@@ -10,6 +10,10 @@ class ForceResetPasswordSerializer(serializers.Serializer):
     new_password = serializers.CharField(trim_whitespace=False)
 
 
+class AdminResetUserPasswordSerializer(serializers.Serializer):
+    new_temporary_password = serializers.CharField(trim_whitespace=False)
+
+
 class CreateUserSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=255)
     email = serializers.EmailField()

--- a/backend/apps/users/api/urls.py
+++ b/backend/apps/users/api/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from .views import (
     AdminUserDetailView,
     AdminUserListCreateView,
+    AdminUserPasswordResetView,
     CurrentUserView,
     ForceResetPasswordView,
     LoginView,
@@ -12,6 +13,11 @@ from .views import (
 urlpatterns = [
     path("admin/users", AdminUserListCreateView.as_view(), name="admin-users"),
     path("admin/users/<uuid:user_id>", AdminUserDetailView.as_view(), name="admin-user-detail"),
+    path(
+        "admin/users/<uuid:user_id>/reset-password",
+        AdminUserPasswordResetView.as_view(),
+        name="admin-user-reset-password",
+    ),
     path("auth/login", LoginView.as_view(), name="auth-login"),
     path("auth/logout", LogoutView.as_view(), name="auth-logout"),
     path("auth/me", CurrentUserView.as_view(), name="auth-me"),

--- a/backend/apps/users/api/views.py
+++ b/backend/apps/users/api/views.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.users.domain.services import (
+    admin_reset_user_password,
     create_user_account,
     DuplicateEmailError,
     InvalidCredentialsError,
@@ -21,6 +22,7 @@ from apps.users.domain.services import (
 )
 
 from .serializers import (
+    AdminResetUserPasswordSerializer,
     AdminUserSerializer,
     CreateUserSerializer,
     ForceResetPasswordSerializer,
@@ -252,6 +254,45 @@ class AdminUserDetailView(APIView):
                 code="VALIDATION_ERROR",
                 message="Invalid input",
                 details={"email": ["A user with this email already exists."]},
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+
+        user_data = AdminUserSerializer(updated_user).data
+        return Response({"user": user_data}, status=status.HTTP_200_OK)
+
+
+@method_decorator(csrf_protect, name="dispatch")
+class AdminUserPasswordResetView(APIView):
+    permission_classes = [IsAdminUser]
+
+    def post(self, request, user_id):
+        serializer = AdminResetUserPasswordSerializer(data=request.data)
+        if not serializer.is_valid():
+            return error_response(
+                code="VALIDATION_ERROR",
+                message="Invalid input",
+                details=serializer.errors,
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            updated_user = admin_reset_user_password(
+                actor=request.user,
+                user_id=user_id,
+                new_temporary_password=serializer.validated_data["new_temporary_password"],
+            )
+        except UserNotFoundError:
+            return error_response(
+                code="USER_NOT_FOUND",
+                message="User not found.",
+                details={},
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
+        except PasswordValidationFailedError as exc:
+            return error_response(
+                code="VALIDATION_ERROR",
+                message="Invalid input",
+                details=exc.details,
                 status_code=status.HTTP_400_BAD_REQUEST,
             )
 

--- a/backend/apps/users/domain/services.py
+++ b/backend/apps/users/domain/services.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from importlib import import_module
 
 from django.conf import settings
 from django.contrib.auth import login as django_login
@@ -15,6 +16,7 @@ from django.contrib.auth.password_validation import (
 )
 from django.core.exceptions import ValidationError
 from django.db import transaction
+from django.contrib.sessions.models import Session
 from django.utils import timezone
 
 
@@ -99,6 +101,21 @@ def validate_user_password(*, user, password: str, field_name: str = "new_passwo
         raise PasswordValidationFailedError({field_name: exc.messages}) from exc
 
 
+def preserve_existing_user_sessions(*, user) -> None:
+    session_hash = user.get_session_auth_hash()
+    session_user_id = str(user.pk)
+    session_store_class = import_module(settings.SESSION_ENGINE).SessionStore
+
+    for session in Session.objects.filter(expire_date__gt=timezone.now()):
+        session_data = session.get_decoded()
+        if session_data.get("_auth_user_id") != session_user_id:
+            continue
+
+        session_data["_auth_user_hash"] = session_hash
+        session.session_data = session_store_class().encode(session_data)
+        session.save(update_fields=["session_data", "expire_date"])
+
+
 @transaction.atomic
 def create_user_account(*, actor, name: str, email: str, temporary_password: str, is_active: bool = True):
     user_model = get_user_model()
@@ -171,6 +188,33 @@ def update_user_account(
 
     if update_fields:
         user.save(update_fields=[*update_fields, "updated_at"])
+
+    return user
+
+
+@transaction.atomic
+def admin_reset_user_password(*, actor, user_id, new_temporary_password: str):
+    user_model = get_user_model()
+    user = (
+        user_model.all_objects.select_for_update()
+        .filter(pk=user_id, deleted_at__isnull=True)
+        .first()
+    )
+
+    if user is None:
+        raise UserNotFoundError
+
+    validate_user_password(
+        user=user,
+        password=new_temporary_password,
+        field_name="new_temporary_password",
+    )
+
+    user.set_password(new_temporary_password)
+    user.must_reset_password = True
+    user.save(update_fields=["password", "must_reset_password", "updated_at"])
+    password_changed(new_temporary_password, user)
+    preserve_existing_user_sessions(user=user)
 
     return user
 

--- a/backend/tests/integration/test_auth_api.py
+++ b/backend/tests/integration/test_auth_api.py
@@ -700,6 +700,184 @@ def test_deactivated_users_cannot_log_in_after_an_admin_deactivates_them():
     }
 
 
+def test_admin_can_reset_a_users_password_and_require_a_forced_reset_on_next_login():
+    admin_user = create_user(
+        email="admin.reset@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    managed_user = create_user(
+        email="reset.target@example.com",
+        password="old-password-123",
+        must_reset_password=False,
+    )
+    client = APIClient()
+    client.force_login(admin_user)
+
+    response = client.post(
+        f"/api/admin/users/{managed_user.id}/reset-password",
+        {"new_temporary_password": "TempPassword456!"},
+        format="json",
+    )
+
+    managed_user.refresh_from_db()
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "user": {
+            "id": str(managed_user.id),
+            "email": managed_user.email,
+            "name": managed_user.name,
+            "is_active": True,
+            "is_admin": False,
+            "must_reset_password": True,
+        }
+    }
+    assert managed_user.must_reset_password is True
+    assert managed_user.check_password("TempPassword456!") is True
+    assert managed_user.check_password("old-password-123") is False
+
+    old_login_client = APIClient()
+    old_login_response = old_login_client.post(
+        "/api/auth/login",
+        {"email": managed_user.email, "password": "old-password-123"},
+        format="json",
+    )
+    new_login_client = APIClient()
+    new_login_response = new_login_client.post(
+        "/api/auth/login",
+        {"email": managed_user.email, "password": "TempPassword456!"},
+        format="json",
+    )
+
+    assert old_login_response.status_code == 401
+    assert new_login_response.status_code == 200
+    assert new_login_response.json()["requires_password_reset"] is True
+    assert new_login_response.json()["user"]["must_reset_password"] is True
+
+
+def test_admin_reset_user_password_validates_the_temporary_password_policy():
+    admin_user = create_user(
+        email="admin.reset-policy@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    managed_user = create_user(email="reset.policy.target@example.com")
+    client = APIClient()
+    client.force_login(admin_user)
+
+    response = client.post(
+        f"/api/admin/users/{managed_user.id}/reset-password",
+        {"new_temporary_password": "short"},
+        format="json",
+    )
+
+    managed_user.refresh_from_db()
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": {
+            "code": "VALIDATION_ERROR",
+            "message": "Invalid input",
+            "details": {
+                "new_temporary_password": [
+                    "This password is too short. It must contain at least 8 characters."
+                ]
+            },
+        }
+    }
+    assert managed_user.check_password("valid-password") is True
+    assert managed_user.must_reset_password is False
+
+
+def test_reset_user_password_denies_non_admin_users():
+    standard_user = create_user(
+        email="member.reset@example.com",
+        is_admin=False,
+        must_reset_password=False,
+    )
+    managed_user = create_user(email="managed.reset@example.com")
+    client = APIClient()
+    client.force_login(standard_user)
+
+    response = client.post(
+        f"/api/admin/users/{managed_user.id}/reset-password",
+        {"new_temporary_password": "TempPassword456!"},
+        format="json",
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Admin access required."}
+
+
+def test_reset_user_password_returns_not_found_for_soft_deleted_users():
+    admin_user = create_user(
+        email="admin.reset-soft-delete@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    managed_user = create_user(
+        email="soft.deleted.reset@example.com",
+        deleted_at=timezone.now(),
+    )
+    client = APIClient()
+    client.force_login(admin_user)
+
+    response = client.post(
+        f"/api/admin/users/{managed_user.id}/reset-password",
+        {"new_temporary_password": "TempPassword456!"},
+        format="json",
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": {
+            "code": "USER_NOT_FOUND",
+            "message": "User not found.",
+            "details": {},
+        }
+    }
+
+
+def test_admin_reset_user_password_preserves_the_targets_existing_session():
+    admin_user = create_user(
+        email="admin.reset-session@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    managed_user = create_user(
+        email="session.reset.target@example.com",
+        password="old-password-123",
+        must_reset_password=False,
+    )
+    target_client = APIClient()
+    target_client.force_login(managed_user)
+    before_response = target_client.get("/api/auth/me")
+
+    admin_client = APIClient()
+    admin_client.force_login(admin_user)
+    reset_response = admin_client.post(
+        f"/api/admin/users/{managed_user.id}/reset-password",
+        {"new_temporary_password": "TempPassword456!"},
+        format="json",
+    )
+
+    managed_user.refresh_from_db()
+    after_response = target_client.get("/api/auth/me")
+
+    assert before_response.status_code == 200
+    assert reset_response.status_code == 200
+    assert managed_user.must_reset_password is True
+    assert after_response.status_code == 200
+    assert after_response.json() == {
+        "id": str(managed_user.id),
+        "email": managed_user.email,
+        "name": managed_user.name,
+        "is_admin": False,
+        "must_reset_password": True,
+    }
+
+
 @override_settings(ROOT_URLCONF=__name__)
 def test_reset_required_user_is_blocked_from_protected_endpoints():
     user = create_user(email="blocked@example.com", must_reset_password=True)

--- a/issues/stories/us-007-reset-user-password.md
+++ b/issues/stories/us-007-reset-user-password.md
@@ -1,8 +1,21 @@
-﻿# US-007 - Reset User Password  ## Metadata - Area: 2. Admin User Management - GitHub labels: `user-story`, `mvp`, `area:admin` - Suggested status: `Backlog` - Suggested wave: `Wave 1` - Depends on: US-005 - Parallelization note: Start once dependencies are done; run in parallel with other stories in the same wave that do not share blocking dependencies.  ## User Story **As an** Admin  
+# US-007 - Reset User Password
+
+## Metadata
+
+- Area: 2. Admin User Management
+- GitHub labels: `user-story`, `mvp`, `area:admin`
+- Suggested status: `Ready`
+- Suggested wave: `Wave 1`
+- Depends on: `US-005`
+- Parallelization note: Start after `US-005`; this story extends the same admin user API surface and shares the password-validation contract from `US-002` and `US-005`.
+
+## User Story
+
+**As an** Admin  
 **I want** to reset a user's password  
 **So that** the user can recover access.
 
-### Acceptance Criteria
+## Acceptance Criteria
 
 **Given** I am an Admin  
 **When** I set a valid temporary password for a user  
@@ -10,43 +23,49 @@
 
 **Given** the temporary password violates password policy  
 **When** I submit the reset request  
-**Then** the system rejects the request.  ## Implementation Breakdown **Kanban lane:** Backlog â†’ Ready â†’ Red â†’ Green â†’ Refactor â†’ Review / QA â†’ Done  
-**Definition of Done:** All listed layer tasks are complete, reviewed, tested, and traceable to the story acceptance criteria.
+**Then** the system rejects the request.
 
-### Database
-- [ ] Confirm user fields support auth state: `is_active`, `deleted_at`, `must_reset_password`, `last_login_at`.
-- [ ] Add indexes/constraints required for email uniqueness and active-user lookup.
+## Execution Breakdown
 
-### Backend/API
-- [ ] Implement/validate session endpoint behavior and generic auth errors.
-- [ ] Enforce active, non-deleted user checks before creating sessions.
-- [ ] Add service-level handling for `must_reset_password` and allowed endpoints.
-- [ ] Emit application logs for security-relevant auth events.
+### Backend Slice
 
-### Frontend/UI
-- [ ] Build guarded route behavior for authenticated, unauthenticated, and reset-required users.
-- [ ] Display validation, generic credential, expired-session, and rate-limit states.
-- [ ] Attach CSRF tokens and credentials on unsafe requests.
+- [x] Add admin-only `POST /api/admin/users/{user_id}/reset-password` under the owning `users` module.
+- [x] Accept only `new_temporary_password` in the request body.
+- [x] Validate the temporary password against the existing password policy.
+- [x] Update the stored password hash and set `must_reset_password = true`.
+- [x] Treat soft-deleted or missing users as not found.
+- [x] Keep password-reset rules in `apps/users/domain/services.py` and keep the view thin.
+- [x] Preserve the target user's existing authenticated sessions after the admin reset, matching the spec rule that reset does not immediately log them out.
 
-### TDD â€” Red: Write Failing Tests First
-- [ ] Map each Given/When/Then acceptance criterion to automated tests.
-- [ ] Add happy-path tests before implementation.
-- [ ] Add validation, permission, and edge-case tests before implementation.
-- [ ] Run the tests and confirm they fail for the expected reason.
-- [ ] Unit test valid/invalid credentials, inactive users, deleted users, and reset-required users.
-- [ ] Integration test full browser/API auth flow and session expiry behavior.
+### Frontend Slice
 
-### TDD â€” Green: Implement Minimum Passing Code
-- [ ] Implement only the smallest database/backend/frontend change needed to pass the failing tests.
-- [ ] Run the story-level test set and confirm all new tests pass.
-- [ ] Confirm existing regression tests still pass.
+- [x] No frontend implementation in this slice.
+- [x] Keep the story backend-only until the admin user-management UI has an owned route surface.
 
-### TDD â€” Refactor: Improve Safely
-- [ ] Refactor duplicated logic into services, validators, hooks, or shared components.
-- [ ] Confirm permissions, structured errors, soft-delete behavior, and edge cases remain covered.
-- [ ] Re-run unit, integration, and relevant frontend tests after refactoring.
+### Test Slice
 
-### Review / QA Checklist
-- [ ] Acceptance criteria from the user story are verified manually or by automated tests.
-- [ ] Structured API errors, permissions, and edge cases are validated where applicable.
-- [ ] Documentation or developer notes are updated if behavior is non-obvious.
+- [x] Add integration coverage for successful admin password reset.
+- [x] Add integration coverage for password-policy rejection on `new_temporary_password`.
+- [x] Add permission coverage showing non-admin users cannot reset another user's password.
+- [x] Add integration coverage showing soft-deleted targets return not found.
+- [x] Add integration coverage proving the new password works on the next login and requires a forced reset.
+- [x] Add integration coverage proving an already-authenticated target session remains valid after the admin reset.
+
+## Dependencies And Notes
+
+- Reuse the existing `validate_user_password()` domain helper and map its field errors onto `new_temporary_password`.
+- Reuse the existing admin-only permission boundary instead of creating a second admin auth path.
+- This story should not implement:
+  - frontend admin reset screens
+  - logout or session-expiration changes
+  - user deactivation semantics from `US-008`
+  - forced-reset submission flow for the target user, which is already covered by `US-002`
+
+## Definition Of Done
+
+- `POST /api/admin/users/{user_id}/reset-password` exists and is admin-only.
+- Valid temporary passwords update the stored password and set `must_reset_password = true`.
+- Invalid temporary passwords return a structured `VALIDATION_ERROR` on `new_temporary_password`.
+- Soft-deleted users cannot be reset through this endpoint.
+- The reset password can be used for the next login, and that login requires the forced-reset flow.
+- Existing authenticated sessions for the target user are not immediately invalidated by the admin reset.

--- a/skills/context/handoffs/2026-05-01-us-007-reset-user-password.md
+++ b/skills/context/handoffs/2026-05-01-us-007-reset-user-password.md
@@ -1,0 +1,39 @@
+# US-007 Reset User Password
+
+## Scope Landed
+
+- Added admin-only `POST /api/admin/users/{user_id}/reset-password` in the `users` module.
+- Delivery is intentionally backend-only for this story slice because the app still has no owned admin user-management UI route surface.
+- The endpoint reuses the same `AdminUserSerializer` payload already used by admin create and update.
+
+## Domain Rules
+
+- Only admins may reset another user's password through this endpoint.
+- The request accepts only `new_temporary_password`.
+- The new temporary password is validated against the same password policy used by forced reset and user creation.
+- A successful admin reset:
+  - updates the stored password hash
+  - sets `must_reset_password = true`
+  - keeps soft-deleted users out of scope by returning not found
+
+## Session Preservation Pattern
+
+- Django would normally invalidate existing authenticated sessions when a user's password hash changes because session auth hashes no longer match.
+- The spec for admin reset explicitly says existing sessions should stay alive until logout or expiry.
+- `admin_reset_user_password()` now updates the password and then rewrites `_auth_user_hash` for active sessions belonging to the target user so those sessions remain valid while still seeing `must_reset_password = true` on later requests.
+
+## Tests Added
+
+- admin can reset a user's password
+- password-policy failures return `VALIDATION_ERROR` on `new_temporary_password`
+- non-admin users are denied
+- soft-deleted targets return not found
+- old password stops working and the new temporary password logs in with `requires_password_reset = true`
+- an already-authenticated target session remains valid after the admin reset
+
+## Branch Context
+
+- Branch: `us-007-reset-user-password`
+- Stack base: `us-006-update-user` / PR `#84`
+- Keep the unrelated `.gitignore` change untouched.
+- Keep the older untracked `2026-05-01-auth-story-stack-through-us-003.md` note out of future PRs unless it is intentionally added.


### PR DESCRIPTION
## Summary
- add admin-only `POST /api/admin/users/{user_id}/reset-password` in the `users` module
- validate `new_temporary_password`, set `must_reset_password = true`, and return the existing admin-user payload
- preserve existing authenticated sessions for the target user after an admin reset, per the spec
- add integration coverage for policy errors, permissions, not-found handling, next-login behavior, and session preservation

## Validation
- `backend\\.venv\\Scripts\\python.exe -m pytest tests/integration/test_auth_api.py`