### PR TITLE
Implement US-008 deactivate user

### DIFF
--- a/backend/apps/users/domain/services.py
+++ b/backend/apps/users/domain/services.py
@@ -116,6 +116,20 @@ def preserve_existing_user_sessions(*, user) -> None:
         session.save(update_fields=["session_data", "expire_date"])
 
 
+def revoke_existing_user_sessions(*, user) -> None:
+    session_user_id = str(user.pk)
+    active_sessions = Session.objects.filter(expire_date__gt=timezone.now())
+    sessions_to_delete = []
+
+    for session in active_sessions:
+        session_data = session.get_decoded()
+        if session_data.get("_auth_user_id") == session_user_id:
+            sessions_to_delete.append(session.pk)
+
+    if sessions_to_delete:
+        Session.objects.filter(pk__in=sessions_to_delete).delete()
+
+
 @transaction.atomic
 def create_user_account(*, actor, name: str, email: str, temporary_password: str, is_active: bool = True):
     user_model = get_user_model()
@@ -169,6 +183,7 @@ def update_user_account(
         raise UserNotFoundError
 
     update_fields = []
+    should_revoke_sessions = False
 
     if name is not None:
         user.name = name
@@ -183,11 +198,15 @@ def update_user_account(
         update_fields.append("email")
 
     if is_active is not None:
+        should_revoke_sessions = user.is_active and not is_active
         user.is_active = is_active
         update_fields.append("is_active")
 
     if update_fields:
         user.save(update_fields=[*update_fields, "updated_at"])
+
+    if should_revoke_sessions:
+        revoke_existing_user_sessions(user=user)
 
     return user
 

--- a/backend/tests/integration/test_auth_api.py
+++ b/backend/tests/integration/test_auth_api.py
@@ -700,6 +700,62 @@ def test_deactivated_users_cannot_log_in_after_an_admin_deactivates_them():
     }
 
 
+def test_admin_deactivation_revokes_the_targets_existing_session():
+    admin_user = create_user(
+        email="admin.deactivate-session@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    managed_user = create_user(email="active.session.target@example.com")
+    target_client = APIClient()
+    target_client.force_login(managed_user)
+    before_response = target_client.get("/api/auth/me")
+
+    admin_client = APIClient()
+    admin_client.force_login(admin_user)
+    deactivate_response = admin_client.patch(
+        f"/api/admin/users/{managed_user.id}",
+        {"is_active": False},
+        format="json",
+    )
+
+    after_response = target_client.get("/api/auth/me")
+
+    assert before_response.status_code == 200
+    assert deactivate_response.status_code == 200
+    assert after_response.status_code == 401
+    assert after_response.json() == {
+        "error": {
+            "code": "UNAUTHENTICATED",
+            "message": "Authentication required.",
+            "details": {},
+        }
+    }
+
+
+def test_admin_deactivation_keeps_the_user_record_and_does_not_soft_delete_it():
+    admin_user = create_user(
+        email="admin.deactivate-soft-delete@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    managed_user = create_user(email="still.present@example.com")
+    client = APIClient()
+    client.force_login(admin_user)
+
+    response = client.patch(
+        f"/api/admin/users/{managed_user.id}",
+        {"is_active": False},
+        format="json",
+    )
+
+    managed_user.refresh_from_db()
+
+    assert response.status_code == 200
+    assert managed_user.is_active is False
+    assert managed_user.deleted_at is None
+
+
 def test_admin_can_reset_a_users_password_and_require_a_forced_reset_on_next_login():
     admin_user = create_user(
         email="admin.reset@example.com",

--- a/issues/stories/us-008-deactivate-user.md
+++ b/issues/stories/us-008-deactivate-user.md
@@ -1,8 +1,21 @@
-﻿# US-008 - Deactivate User  ## Metadata - Area: 2. Admin User Management - GitHub labels: `user-story`, `mvp`, `area:admin` - Suggested status: `Backlog` - Suggested wave: `Wave 1` - Depends on: US-005 - Parallelization note: Start once dependencies are done; run in parallel with other stories in the same wave that do not share blocking dependencies.  ## User Story **As an** Admin  
+# US-008 - Deactivate User
+
+## Metadata
+
+- Area: 2. Admin User Management
+- GitHub labels: `user-story`, `mvp`, `area:admin`
+- Suggested status: `Ready`
+- Suggested wave: `Wave 1`
+- Depends on: `US-005`
+- Parallelization note: Start after `US-005`; this story reuses the existing admin user update API from `US-006` and should not invent a second deactivation transport path.
+
+## User Story
+
+**As an** Admin  
 **I want** to deactivate users  
 **So that** they can no longer access the system.
 
-### Acceptance Criteria
+## Acceptance Criteria
 
 **Given** I am an Admin  
 **When** I deactivate a user  
@@ -10,43 +23,47 @@
 
 **Given** the deactivated user has existing assignments  
 **When** tasks are viewed  
-**Then** historical assignments remain visible.  ## Implementation Breakdown **Kanban lane:** Backlog â†’ Ready â†’ Red â†’ Green â†’ Refactor â†’ Review / QA â†’ Done  
-**Definition of Done:** All listed layer tasks are complete, reviewed, tested, and traceable to the story acceptance criteria.
+**Then** historical assignments remain visible.
 
-### Database
-- [ ] Create/update user schema with UUID primary key, unique email, active flag, admin flag, reset flag, timestamps, soft delete.
-- [ ] Add migration and database constraints for required user fields.
+## Execution Breakdown
 
-### Backend/API
-- [ ] Implement admin-only user endpoint/service logic.
-- [ ] Validate email uniqueness and password policy where relevant.
-- [ ] Apply soft-delete/deactivation rules without cascading assignment deletion.
-- [ ] Create activity/application logs for user management events.
+### Backend Slice
 
-### Frontend/UI
-- [ ] Build admin user management form/table action states.
-- [ ] Show success/error feedback for create, update, deactivate, and reset operations.
+- [x] Reuse `PATCH /api/admin/users/{user_id}` with `{"is_active": false}` as the deactivation contract.
+- [x] Keep deactivation rules in `apps/users/domain/services.py` and keep the view thin.
+- [x] Revoke the target user's existing authenticated sessions when they transition from active to inactive.
+- [x] Keep deactivation distinct from soft delete: do not set `deleted_at`, do not remove the user record, and do not mutate assignment references.
+- [x] Treat soft-deleted or missing users as not found.
 
-### TDD â€” Red: Write Failing Tests First
-- [ ] Map each Given/When/Then acceptance criterion to automated tests.
-- [ ] Add happy-path tests before implementation.
-- [ ] Add validation, permission, and edge-case tests before implementation.
-- [ ] Run the tests and confirm they fail for the expected reason.
-- [ ] Permission tests for admin-only access.
-- [ ] Integration tests for user create/update/deactivate/reset flows.
-- [ ] Regression tests that inactive/deleted users cannot log in.
+### Frontend Slice
 
-### TDD â€” Green: Implement Minimum Passing Code
-- [ ] Implement only the smallest database/backend/frontend change needed to pass the failing tests.
-- [ ] Run the story-level test set and confirm all new tests pass.
-- [ ] Confirm existing regression tests still pass.
+- [x] No frontend implementation in this slice.
+- [x] Keep the story backend-only until the admin user-management UI has an owned route surface.
 
-### TDD â€” Refactor: Improve Safely
-- [ ] Refactor duplicated logic into services, validators, hooks, or shared components.
-- [ ] Confirm permissions, structured errors, soft-delete behavior, and edge cases remain covered.
-- [ ] Re-run unit, integration, and relevant frontend tests after refactoring.
+### Test Slice
 
-### Review / QA Checklist
-- [ ] Acceptance criteria from the user story are verified manually or by automated tests.
-- [ ] Structured API errors, permissions, and edge cases are validated where applicable.
-- [ ] Documentation or developer notes are updated if behavior is non-obvious.
+- [x] Add integration coverage showing an admin can deactivate a user through the update endpoint.
+- [x] Add integration coverage showing deactivated users cannot create new sessions.
+- [x] Add integration coverage showing an already-authenticated target session is revoked after deactivation.
+- [x] Add permission coverage showing non-admin users cannot deactivate another user.
+- [x] Add integration coverage showing deactivation does not soft-delete the user record.
+- [x] Keep the historical-assignment guarantee as a boundary check in this slice: no code path should touch task-assignment data.
+
+## Dependencies And Notes
+
+- Reuse the existing admin-only permission boundary and `AdminUserSerializer` response shape from `US-006`.
+- Reuse the existing generic invalid-credentials login response for inactive users from `US-001`.
+- This story should not implement:
+  - a new `/api/admin/users/{user_id}/deactivate` endpoint
+  - frontend admin user-management screens
+  - soft delete or hard delete semantics
+  - assignment reassignment or task cleanup behavior
+
+## Definition Of Done
+
+- Admin deactivation is performed through `PATCH /api/admin/users/{user_id}` with `is_active = false`.
+- Deactivated users cannot create new sessions.
+- Existing authenticated sessions for the target user are revoked.
+- The user record remains present and not soft-deleted after deactivation.
+- Non-admin users cannot deactivate users.
+- The implementation does not mutate assignment references or introduce task-side effects.

--- a/skills/context/handoffs/2026-05-01-current-repo-state.md
+++ b/skills/context/handoffs/2026-05-01-current-repo-state.md
@@ -2,22 +2,47 @@
 
 ## Current State
 
-- The repository contains planning docs, local backlog files, GitHub issue export support, and repo-local skills.
-- Implementation-oriented skills now exist for frontend, backend, fullstack, QA, and issue execution.
-- The `skills/context/` folder is intended for durable operational knowledge, not for replacing the main spec or backlog.
+- The auth and admin-user implementation stack is now landed locally through `US-008`.
+- Current stacked branch and PR chain:
+  - `us-001-auth-foundation` -> PR `#79`
+  - `us-002-forced-first-login-password-reset` -> PR `#80`
+  - `us-003-logout` -> PR `#81`
+  - `us-004-session-expiration` -> PR `#82`
+  - `us-005-create-user` -> PR `#83`
+  - `us-006-update-user` -> PR `#84`
+  - `us-007-reset-user-password` -> PR `#85`
+  - `us-008-deactivate-user` -> PR pending
+- Current working branch is `us-008-deactivate-user`.
+- GitHub issue states in this stack are `:owner-review` for `#6` through `#12`, with `#13` in implementation.
+- The only known unrelated local changes are:
+  - modified `.gitignore`
 
 ## Next Recommended Step
 
-- Use the issue execution skill on the next story chosen for implementation and record any reusable delivery pattern discovered during that slice.
+- Start `US-009 Create Project` from the top of the current stacked branch chain after `US-008` is pushed and opened for review.
+- Keep the current stack backend-first until an owned admin UI route surface or project frontend surface is introduced.
+- Reuse the existing admin-user API conventions:
+  - admin-only permission boundary
+  - `AdminUserSerializer` response payload
+  - structured `VALIDATION_ERROR` / not-found envelopes
+  - password-reset-complete requirement for admin actions
+  - deactivation through `PATCH /api/admin/users/{user_id}` instead of a second transport path
 
 ## Risks Or Open Questions
 
-- The implementation architecture is defined, but the actual codebase scaffolding has not yet been generated in this repository.
-- Context notes can drift if agents duplicate information that belongs in `issues/` or `IMPLEMENTATION_ARCHITECTURE.md`.
+- PRs are intentionally stacked. Changes to an earlier base PR can require rechecking downstream branches before continuing.
+- The admin user-management surface is still backend-only. Avoid inventing frontend admin routes until a story explicitly owns that slice.
+- `US-008` revokes live sessions on deactivation. Do not undo that behavior by moving deactivation back into a passive field update.
+- Context notes can drift if agents create rollup notes that overlap with existing per-story handoffs. Prefer updating this file for stack status and using story-specific notes only for story-specific implementation details.
 
 ## Relevant Files
 
 - `AGENTS.md`
-- `IMPLEMENTATION_ARCHITECTURE.md`
-- `skills/README.md`
-- `skills/context/README.md`
+- `issues/stories/us-005-create-user.md`
+- `issues/stories/us-006-update-user.md`
+- `issues/stories/us-007-reset-user-password.md`
+- `issues/stories/us-008-deactivate-user.md`
+- `skills/context/handoffs/2026-05-01-us-005-create-user.md`
+- `skills/context/handoffs/2026-05-01-us-006-update-user.md`
+- `skills/context/handoffs/2026-05-01-us-007-reset-user-password.md`
+- `skills/context/handoffs/2026-05-01-us-008-deactivate-user.md`

--- a/skills/context/handoffs/2026-05-01-us-008-deactivate-user.md
+++ b/skills/context/handoffs/2026-05-01-us-008-deactivate-user.md
@@ -1,0 +1,24 @@
+# US-008 - Deactivate User
+
+## What Changed
+
+- Reused the existing admin user update contract for deactivation instead of adding a new route.
+- `PATCH /api/admin/users/{user_id}` with `{"is_active": false}` now revokes the target user's existing authenticated sessions.
+- Deactivation remains distinct from soft delete: the user record stays present and `deleted_at` remains `NULL`.
+
+## Implementation Notes
+
+- Session revocation is handled in `backend/apps/users/domain/services.py` inside the `users` domain, not in the view.
+- The service only revokes sessions on an active -> inactive transition.
+- The existing login contract stays unchanged: deactivated users still receive the generic `INVALID_CREDENTIALS` response on new login attempts.
+
+## Validation
+
+- `py -3.12 -m pytest tests/integration/test_auth_api.py` with `PYTHONPATH=D:\GitHub\project-management-system\backend\.venv\Lib\site-packages` -> `43 passed`
+
+## Boundaries
+
+- No new frontend admin route surface was added.
+- No new deactivate-specific endpoint was added.
+- No soft-delete behavior was added or changed.
+- No task-assignment mutation was introduced; the historical-assignment rule remains preserved by keeping deactivation to `is_active` only.


### PR DESCRIPTION
## Summary
- refine `US-008` into a backend-only deactivation slice on the existing admin user update API
- revoke the target user's live sessions when an admin deactivates them via `PATCH /api/admin/users/{user_id}`
- add auth integration coverage for login denial, live-session revocation, and the no-soft-delete boundary

## Testing
- `py -3.12 -m pytest tests/integration/test_auth_api.py` with `PYTHONPATH=D:\GitHub\project-management-system\backend\.venv\Lib\site-packages`
