### PR TITLE
Implement US-058 authentication rate limits

### DIFF
--- a/backend/apps/users/api/views.py
+++ b/backend/apps/users/api/views.py
@@ -7,6 +7,7 @@ from rest_framework.views import APIView
 
 from apps.users.domain.services import (
     admin_reset_user_password,
+    AuthenticationRateLimitedError,
     create_user_account,
     DuplicateEmailError,
     InvalidCredentialsError,
@@ -67,6 +68,15 @@ class LoginView(APIView):
                 email=serializer.validated_data["email"],
                 password=serializer.validated_data["password"],
             )
+        except AuthenticationRateLimitedError as exc:
+            response = error_response(
+                code="RATE_LIMITED",
+                message="Too many authentication attempts. Try again later.",
+                details={"retry_after": exc.retry_after},
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            )
+            response["Retry-After"] = str(exc.retry_after)
+            return response
         except InvalidCredentialsError:
             return error_response(
                 code="INVALID_CREDENTIALS",
@@ -132,6 +142,15 @@ class ForceResetPasswordView(APIView):
                 user=session_user,
                 new_password=serializer.validated_data["new_password"],
             )
+        except AuthenticationRateLimitedError as exc:
+            response = error_response(
+                code="RATE_LIMITED",
+                message="Too many authentication attempts. Try again later.",
+                details={"retry_after": exc.retry_after},
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            )
+            response["Retry-After"] = str(exc.retry_after)
+            return response
         except PasswordValidationFailedError as exc:
             return error_response(
                 code="VALIDATION_ERROR",

--- a/backend/apps/users/domain/services.py
+++ b/backend/apps/users/domain/services.py
@@ -15,6 +15,7 @@ from django.contrib.auth.password_validation import (
     validate_password,
 )
 from django.core.exceptions import ValidationError
+from django.core.cache import cache
 from django.db import transaction
 from django.contrib.sessions.models import Session
 from django.utils import timezone
@@ -42,6 +43,12 @@ class UserNotFoundError(Exception):
     pass
 
 
+class AuthenticationRateLimitedError(Exception):
+    def __init__(self, retry_after: int):
+        super().__init__("Authentication rate limit exceeded.")
+        self.retry_after = retry_after
+
+
 @dataclass(frozen=True)
 class AuthenticatedSession:
     user: object
@@ -54,6 +61,94 @@ DEFAULT_PASSWORD_VALIDATORS = [
     CommonPasswordValidator(),
     NumericPasswordValidator(),
 ]
+
+
+def get_client_ip(*, request) -> str:
+    forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR", "")
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+
+    return request.META.get("REMOTE_ADDR", "unknown")
+
+
+def _rate_limit_key(*, scope: str, identifier: str) -> str:
+    return f"auth-rate-limit:{scope}:{identifier}"
+
+
+def _record_failed_attempt(*, scope: str, identifier: str) -> bool:
+    max_attempts = settings.AUTH_RATE_LIMIT_MAX_ATTEMPTS
+    window_seconds = settings.AUTH_RATE_LIMIT_WINDOW_SECONDS
+    key = _rate_limit_key(scope=scope, identifier=identifier)
+    attempts = cache.get(key, 0) + 1
+    cache.set(key, attempts, timeout=window_seconds)
+    return attempts > max_attempts
+
+
+def _is_rate_limited(*, scope: str, identifier: str) -> bool:
+    return cache.get(_rate_limit_key(scope=scope, identifier=identifier), 0) >= (
+        settings.AUTH_RATE_LIMIT_MAX_ATTEMPTS
+    )
+
+
+def _clear_rate_limit(*, scope: str, identifier: str) -> None:
+    cache.delete(_rate_limit_key(scope=scope, identifier=identifier))
+
+
+def ensure_login_not_rate_limited(*, request, email: str) -> None:
+    normalized_email = get_user_model().objects.normalize_email(email).lower()
+    client_ip = get_client_ip(request=request)
+    scoped_identifiers = (
+        _rate_limit_key(scope="login:ip", identifier=client_ip),
+        _rate_limit_key(scope="login:email", identifier=normalized_email),
+    )
+
+    if any(cache.get(identifier, 0) >= settings.AUTH_RATE_LIMIT_MAX_ATTEMPTS for identifier in scoped_identifiers):
+        raise AuthenticationRateLimitedError(settings.AUTH_RATE_LIMIT_WINDOW_SECONDS)
+
+
+def record_failed_login_attempt(*, request, email: str) -> None:
+    normalized_email = get_user_model().objects.normalize_email(email).lower()
+    client_ip = get_client_ip(request=request)
+    ip_limited = _record_failed_attempt(scope="login:ip", identifier=client_ip)
+    email_limited = _record_failed_attempt(scope="login:email", identifier=normalized_email)
+
+    if ip_limited or email_limited:
+        raise AuthenticationRateLimitedError(settings.AUTH_RATE_LIMIT_WINDOW_SECONDS)
+
+
+def clear_login_rate_limit(*, request, email: str) -> None:
+    normalized_email = get_user_model().objects.normalize_email(email).lower()
+    client_ip = get_client_ip(request=request)
+    _clear_rate_limit(scope="login:ip", identifier=client_ip)
+    _clear_rate_limit(scope="login:email", identifier=normalized_email)
+
+
+def ensure_force_reset_not_rate_limited(*, request, user) -> None:
+    client_ip = get_client_ip(request=request)
+    user_identifier = str(user.pk)
+
+    if (
+        _is_rate_limited(scope="force-reset:ip", identifier=client_ip)
+        or _is_rate_limited(scope="force-reset:user", identifier=user_identifier)
+    ):
+        raise AuthenticationRateLimitedError(settings.AUTH_RATE_LIMIT_WINDOW_SECONDS)
+
+
+def record_failed_force_reset_attempt(*, request, user) -> None:
+    client_ip = get_client_ip(request=request)
+    user_identifier = str(user.pk)
+    ip_limited = _record_failed_attempt(scope="force-reset:ip", identifier=client_ip)
+    user_limited = _record_failed_attempt(scope="force-reset:user", identifier=user_identifier)
+
+    if ip_limited or user_limited:
+        raise AuthenticationRateLimitedError(settings.AUTH_RATE_LIMIT_WINDOW_SECONDS)
+
+
+def clear_force_reset_rate_limit(*, request, user) -> None:
+    client_ip = get_client_ip(request=request)
+    user_identifier = str(user.pk)
+    _clear_rate_limit(scope="force-reset:ip", identifier=client_ip)
+    _clear_rate_limit(scope="force-reset:user", identifier=user_identifier)
 
 
 def serialize_session_user(user) -> dict[str, str | bool]:
@@ -240,6 +335,7 @@ def admin_reset_user_password(*, actor, user_id, new_temporary_password: str):
 
 @transaction.atomic
 def force_reset_password(*, request, user, new_password: str):
+    ensure_force_reset_not_rate_limited(request=request, user=user)
     locked_user = user.__class__.all_objects.select_for_update().get(pk=user.pk)
 
     if locked_user.deleted_at is not None or not locked_user.is_active:
@@ -247,15 +343,21 @@ def force_reset_password(*, request, user, new_password: str):
         return None
 
     if not locked_user.must_reset_password:
+        record_failed_force_reset_attempt(request=request, user=locked_user)
         raise PasswordResetNotRequiredError
 
-    validate_user_password(user=locked_user, password=new_password)
+    try:
+        validate_user_password(user=locked_user, password=new_password)
+    except PasswordValidationFailedError:
+        record_failed_force_reset_attempt(request=request, user=locked_user)
+        raise
 
     locked_user.set_password(new_password)
     locked_user.must_reset_password = False
     locked_user.save(update_fields=["password", "must_reset_password", "updated_at"])
     password_changed(new_password, locked_user)
     update_session_auth_hash(request, locked_user)
+    clear_force_reset_rate_limit(request=request, user=locked_user)
 
     return locked_user
 
@@ -264,6 +366,7 @@ def force_reset_password(*, request, user, new_password: str):
 def authenticate_user_session(*, request, email: str, password: str) -> AuthenticatedSession:
     user_model = get_user_model()
     normalized_email = user_model.objects.normalize_email(email).lower()
+    ensure_login_not_rate_limited(request=request, email=normalized_email)
     user = (
         user_model.all_objects.select_for_update()
         .filter(email__iexact=normalized_email)
@@ -271,14 +374,17 @@ def authenticate_user_session(*, request, email: str, password: str) -> Authenti
     )
 
     if user is None or user.deleted_at is not None or not user.is_active:
+        record_failed_login_attempt(request=request, email=normalized_email)
         raise InvalidCredentialsError
 
     if not user.check_password(password):
+        record_failed_login_attempt(request=request, email=normalized_email)
         raise InvalidCredentialsError
 
     user.last_login_at = timezone.now()
     user.save(update_fields=["last_login_at", "updated_at"])
     django_login(request, user, backend=settings.AUTHENTICATION_BACKENDS[0])
+    clear_login_rate_limit(request=request, email=normalized_email)
 
     return AuthenticatedSession(
         user=user,

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -135,3 +135,5 @@ CSRF_TRUSTED_ORIGINS = [
     ).split(",")
     if origin.strip()
 ]
+AUTH_RATE_LIMIT_MAX_ATTEMPTS = int(os.getenv("AUTH_RATE_LIMIT_MAX_ATTEMPTS", "5"))
+AUTH_RATE_LIMIT_WINDOW_SECONDS = int(os.getenv("AUTH_RATE_LIMIT_WINDOW_SECONDS", "900"))

--- a/backend/tests/integration/test_auth_api.py
+++ b/backend/tests/integration/test_auth_api.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 import pytest
 from django.conf import settings
+from django.core.cache import cache
 from django.test import override_settings
 from django.urls import include, path
 from django.contrib.auth import get_user_model
@@ -15,6 +16,11 @@ from apps.users.api.permissions import IsAuthenticatedAndPasswordResetComplete
 
 
 pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def clear_auth_rate_limit_cache():
+    cache.clear()
 
 
 class ProtectedAppView(APIView):
@@ -296,6 +302,37 @@ def test_force_reset_password_succeeds_with_a_valid_csrf_token():
     assert response.status_code == 200
 
 
+@override_settings(AUTH_RATE_LIMIT_MAX_ATTEMPTS=2, AUTH_RATE_LIMIT_WINDOW_SECONDS=60)
+def test_failed_force_reset_attempts_are_rate_limited():
+    user = create_user(email="force-limit@example.com", must_reset_password=True)
+    client = APIClient()
+    client.force_login(user)
+
+    first_response = client.post(
+        "/api/auth/force-reset-password",
+        {"new_password": "short"},
+        format="json",
+        REMOTE_ADDR="10.0.2.1",
+    )
+    second_response = client.post(
+        "/api/auth/force-reset-password",
+        {"new_password": "short"},
+        format="json",
+        REMOTE_ADDR="10.0.2.1",
+    )
+    third_response = client.post(
+        "/api/auth/force-reset-password",
+        {"new_password": "short"},
+        format="json",
+        REMOTE_ADDR="10.0.2.1",
+    )
+
+    assert first_response.status_code == 400
+    assert second_response.status_code == 400
+    assert third_response.status_code == 429
+    assert third_response.json()["error"]["code"] == "RATE_LIMITED"
+
+
 def test_current_user_returns_authenticated_profile_for_reset_required_user():
     user = create_user(email="reset-bootstrap@example.com", must_reset_password=True)
     client = APIClient()
@@ -342,6 +379,109 @@ def test_login_succeeds_with_valid_csrf_token():
 
     assert response.status_code == 200
     assert response.json()["user"]["email"] == user.email
+
+
+@override_settings(AUTH_RATE_LIMIT_MAX_ATTEMPTS=2, AUTH_RATE_LIMIT_WINDOW_SECONDS=60)
+def test_failed_login_attempts_are_rate_limited_by_email():
+    user = create_user(email="limited@example.com")
+    client = APIClient()
+
+    first_response = client.post(
+        "/api/auth/login",
+        {"email": user.email, "password": "wrong-password"},
+        format="json",
+        REMOTE_ADDR="10.0.0.1",
+    )
+    second_response = client.post(
+        "/api/auth/login",
+        {"email": user.email, "password": "wrong-password"},
+        format="json",
+        REMOTE_ADDR="10.0.0.2",
+    )
+    third_response = client.post(
+        "/api/auth/login",
+        {"email": user.email, "password": "wrong-password"},
+        format="json",
+        REMOTE_ADDR="10.0.0.3",
+    )
+
+    assert first_response.status_code == 401
+    assert second_response.status_code == 401
+    assert third_response.status_code == 429
+    assert third_response.json() == {
+        "error": {
+            "code": "RATE_LIMITED",
+            "message": "Too many authentication attempts. Try again later.",
+            "details": {"retry_after": 60},
+        }
+    }
+    assert third_response["Retry-After"] == "60"
+
+
+@override_settings(AUTH_RATE_LIMIT_MAX_ATTEMPTS=2, AUTH_RATE_LIMIT_WINDOW_SECONDS=60)
+def test_failed_login_attempts_are_rate_limited_by_ip():
+    client = APIClient()
+
+    first_response = client.post(
+        "/api/auth/login",
+        {"email": "missing.one@example.com", "password": "wrong-password"},
+        format="json",
+        REMOTE_ADDR="10.10.10.10",
+    )
+    second_response = client.post(
+        "/api/auth/login",
+        {"email": "missing.two@example.com", "password": "wrong-password"},
+        format="json",
+        REMOTE_ADDR="10.10.10.10",
+    )
+    third_response = client.post(
+        "/api/auth/login",
+        {"email": "missing.three@example.com", "password": "wrong-password"},
+        format="json",
+        REMOTE_ADDR="10.10.10.10",
+    )
+
+    assert first_response.status_code == 401
+    assert second_response.status_code == 401
+    assert third_response.status_code == 429
+    assert third_response.json()["error"]["code"] == "RATE_LIMITED"
+
+
+@override_settings(AUTH_RATE_LIMIT_MAX_ATTEMPTS=3, AUTH_RATE_LIMIT_WINDOW_SECONDS=60)
+def test_successful_login_clears_accumulated_rate_limit_failures():
+    user = create_user(email="clear-limit@example.com")
+    client = APIClient()
+
+    first_failure = client.post(
+        "/api/auth/login",
+        {"email": user.email, "password": "wrong-password"},
+        format="json",
+        REMOTE_ADDR="10.0.1.1",
+    )
+    second_failure = client.post(
+        "/api/auth/login",
+        {"email": user.email, "password": "wrong-password"},
+        format="json",
+        REMOTE_ADDR="10.0.1.1",
+    )
+    success_response = client.post(
+        "/api/auth/login",
+        {"email": user.email, "password": "valid-password"},
+        format="json",
+        REMOTE_ADDR="10.0.1.1",
+    )
+    after_success_failure = client.post(
+        "/api/auth/login",
+        {"email": user.email, "password": "wrong-password"},
+        format="json",
+        REMOTE_ADDR="10.0.1.1",
+    )
+
+    assert first_failure.status_code == 401
+    assert second_failure.status_code == 401
+    assert success_response.status_code == 200
+    assert after_success_failure.status_code == 401
+    assert after_success_failure.json()["error"]["code"] == "INVALID_CREDENTIALS"
 
 
 def test_admin_create_user_requires_a_valid_csrf_token():

--- a/backend/tests/integration/test_projects_api.py
+++ b/backend/tests/integration/test_projects_api.py
@@ -1,5 +1,6 @@
 import pytest
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from rest_framework.test import APIClient
 
 from apps.memberships.models import ProjectMembership, ProjectMembershipRole
@@ -7,6 +8,11 @@ from apps.projects.models import Project
 
 
 pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def clear_project_rate_limit_cache():
+    cache.clear()
 
 
 def create_user(**overrides):

--- a/frontend/src/features/auth/AuthFlow.test.tsx
+++ b/frontend/src/features/auth/AuthFlow.test.tsx
@@ -172,6 +172,44 @@ describe("auth flow", () => {
     expect(screen.getByRole("heading", { name: /user login/i })).toBeInTheDocument();
   });
 
+  it("shows the rate-limit error returned by the backend", async () => {
+    mockFetchSequence([
+      jsonResponse({
+        status: 401,
+        body: {
+          error: {
+            code: "UNAUTHENTICATED",
+            message: "Authentication required.",
+            details: {},
+          },
+        },
+      }),
+      jsonResponse({
+        status: 429,
+        body: {
+          error: {
+            code: "RATE_LIMITED",
+            message: "Too many authentication attempts. Try again later.",
+            details: {
+              retry_after: 60,
+            },
+          },
+        },
+      }),
+    ]);
+
+    const user = userEvent.setup();
+    renderApp(["/login"], { cookie: "csrftoken=test-token; path=/" });
+    await user.type(await screen.findByLabelText(/email/i), "jane@example.com");
+    await user.type(screen.getByLabelText(/password/i), "wrong-password");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    expect(
+      await screen.findByText("Too many authentication attempts. Try again later."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /user login/i })).toBeInTheDocument();
+  });
+
   it("boots directly into the authenticated shell when a session already exists", async () => {
     mockFetchSequence([
       jsonResponse({

--- a/frontend/src/features/auth/pages/LoginPage.tsx
+++ b/frontend/src/features/auth/pages/LoginPage.tsx
@@ -33,6 +33,10 @@ export function LoginPage() {
     isApiError(loginMutation.error) && loginMutation.error.code === "INVALID_CREDENTIALS"
       ? loginMutation.error.message
       : null;
+  const rateLimitedError =
+    isApiError(loginMutation.error) && loginMutation.error.code === "RATE_LIMITED"
+      ? loginMutation.error.message
+      : null;
 
   return (
     <AuthFrame
@@ -73,6 +77,11 @@ export function LoginPage() {
           {loginError ? (
             <StatusMessage tone="error" title="Sign-in failed">
               {loginError}
+            </StatusMessage>
+          ) : null}
+          {rateLimitedError ? (
+            <StatusMessage tone="error" title="Too many attempts">
+              {rateLimitedError}
             </StatusMessage>
           ) : null}
           <Button disabled={loginMutation.isPending} fullWidth type="submit">

--- a/issues/stories/us-058-rate-limit-authentication-endpoints.md
+++ b/issues/stories/us-058-rate-limit-authentication-endpoints.md
@@ -1,8 +1,21 @@
-﻿# US-058 - Rate-Limit Authentication Endpoints  ## Metadata - Area: 17. Authorization and Security - GitHub labels: `user-story`, `mvp`, `area:security` - Suggested status: `Backlog` - Suggested wave: `Wave 1` - Depends on: US-001 - Parallelization note: Start once dependencies are done; run in parallel with other stories in the same wave that do not share blocking dependencies.  ## User Story **As a** system  
+# US-058 - Rate-Limit Authentication Endpoints
+
+## Metadata
+
+- Area: 17. Authorization and Security
+- GitHub labels: `user-story`, `mvp`, `area:security`
+- Suggested status: `Ready`
+- Suggested wave: `Wave 1`
+- Depends on: `US-001`
+- Parallelization note: This slice can build directly on the auth foundation and the CSRF hardening work from `US-057`.
+
+## User Story
+
+**As a** system  
 **I want** authentication endpoints to be rate-limited  
 **So that** brute-force attempts are reduced.
 
-### Acceptance Criteria
+## Acceptance Criteria
 
 **Given** repeated failed login attempts occur from the same IP or email  
 **When** the limit is exceeded  
@@ -10,46 +23,43 @@
 
 **Given** an authentication failure occurs  
 **When** the error is returned  
-**Then** the message does not reveal whether the email exists or account is inactive.  ## Implementation Breakdown **Kanban lane:** Backlog â†’ Ready â†’ Red â†’ Green â†’ Refactor â†’ Review / QA â†’ Done  
-**Definition of Done:** All listed layer tasks are complete, reviewed, tested, and traceable to the story acceptance criteria.
+**Then** the message does not reveal whether the email exists or account is inactive.
 
-### Database
-- [ ] Confirm user fields support auth state: `is_active`, `deleted_at`, `must_reset_password`, `last_login_at`.
-- [ ] Add indexes/constraints required for email uniqueness and active-user lookup.
+## Execution Breakdown
 
-### Backend/API
-- [ ] Implement/validate session endpoint behavior and generic auth errors.
-- [ ] Enforce active, non-deleted user checks before creating sessions.
-- [ ] Add service-level handling for `must_reset_password` and allowed endpoints.
-- [ ] Emit application logs for security-relevant auth events.
+### Backend Slice
 
-### Frontend/UI
-- [ ] Build guarded route behavior for authenticated, unauthenticated, and reset-required users.
-- [ ] Display validation, generic credential, expired-session, and rate-limit states.
-- [ ] Attach CSRF tokens and credentials on unsafe requests.
+- [x] Add cache-backed failure tracking for authentication endpoints under the `users` module.
+- [x] Enforce failed-login throttling by both client IP and normalized email.
+- [x] Reuse the existing generic `INVALID_CREDENTIALS` login failure for wrong password, inactive user, and missing user.
+- [x] Return a structured `RATE_LIMITED` error with HTTP `429` when the threshold is exceeded.
+- [x] Apply the same rate-limit pattern to the implemented forced-reset endpoint so the current auth endpoint surface is covered.
+- [x] Clear the relevant failure counters after a successful login.
 
-### TDD â€” Red: Write Failing Tests First
-- [ ] Map each Given/When/Then acceptance criterion to automated tests.
-- [ ] Add happy-path tests before implementation.
-- [ ] Add validation, permission, and edge-case tests before implementation.
-- [ ] Run the tests and confirm they fail for the expected reason.
-- [ ] Unit test valid/invalid credentials, inactive users, deleted users, and reset-required users.
-- [ ] Integration test full browser/API auth flow and session expiry behavior.
+### Frontend Slice
 
-### DevOps/Config
-- [ ] Configure secure cookie settings and rate-limit middleware for production/staging.
+- [x] Keep the shared client and login flow intact.
+- [x] Add explicit login-form handling for the `RATE_LIMITED` backend error state.
+- [x] Surface a visible rate-limit message without exposing account existence details.
 
-### TDD â€” Green: Implement Minimum Passing Code
-- [ ] Implement only the smallest database/backend/frontend change needed to pass the failing tests.
-- [ ] Run the story-level test set and confirm all new tests pass.
-- [ ] Confirm existing regression tests still pass.
+### Test Slice
 
-### TDD â€” Refactor: Improve Safely
-- [ ] Refactor duplicated logic into services, validators, hooks, or shared components.
-- [ ] Confirm permissions, structured errors, soft-delete behavior, and edge cases remain covered.
-- [ ] Re-run unit, integration, and relevant frontend tests after refactoring.
+- [x] Add backend integration coverage showing repeated failed logins from the same email are rate-limited.
+- [x] Add backend integration coverage showing repeated failed logins from the same IP are rate-limited.
+- [x] Add backend integration coverage proving a successful login clears the accumulated login failure counters.
+- [x] Add backend integration coverage showing forced-reset failures are rate-limited on the implemented endpoint surface.
+- [x] Keep or add frontend integration coverage showing the login form renders the rate-limit message.
 
-### Review / QA Checklist
-- [ ] Acceptance criteria from the user story are verified manually or by automated tests.
-- [ ] Structured API errors, permissions, and edge cases are validated where applicable.
-- [ ] Documentation or developer notes are updated if behavior is non-obvious.
+## Dependencies And Notes
+
+- This slice should use the Django cache backend already available in the project instead of introducing external infrastructure-specific middleware.
+- This slice should not reveal whether an email exists, whether the account is inactive, or which credential was wrong.
+- This slice does not need to implement `/auth/change-password`, which is not yet part of the current repo surface.
+
+## Definition Of Done
+
+- Repeated failed login attempts are rate-limited by both IP and email.
+- Successful login clears the relevant login failure counters.
+- Implemented authentication endpoints return a structured `RATE_LIMITED` response with HTTP `429` when blocked.
+- Generic invalid-credential responses remain generic and non-revealing.
+- The frontend login flow shows a clear rate-limit message when the backend returns `RATE_LIMITED`.

--- a/skills/context/handoffs/2026-05-02-us-058-rate-limit-authentication-endpoints.md
+++ b/skills/context/handoffs/2026-05-02-us-058-rate-limit-authentication-endpoints.md
@@ -1,0 +1,24 @@
+# US-058 - Rate-Limit Authentication Endpoints
+
+## What Changed
+
+- Added cache-backed authentication failure counters in the `users` domain service layer.
+- Repeated failed login attempts are now rate-limited by both client IP and normalized email.
+- Repeated failed forced-reset attempts are also rate-limited on the implemented endpoint surface.
+- The login form now renders the backend `RATE_LIMITED` error state explicitly.
+
+## Implementation Notes
+
+- The current implementation uses the Django cache backend with configurable settings:
+  - `AUTH_RATE_LIMIT_MAX_ATTEMPTS`
+  - `AUTH_RATE_LIMIT_WINDOW_SECONDS`
+- Structured `429` responses use:
+  - error code `RATE_LIMITED`
+  - `details.retry_after`
+  - `Retry-After` response header
+- Successful login clears the accumulated rate-limit counters for the matching IP and normalized email.
+
+## Validation
+
+- Backend: `py -3.12 -m pytest tests/integration/test_auth_api.py tests/integration/test_projects_api.py` with `PYTHONPATH=D:\GitHub\project-management-system\backend\.venv\Lib\site-packages` -> `60 passed`
+- Frontend: `npm run test:run -- src/features/auth/AuthFlow.test.tsx src/features/projects/ProjectsFlow.test.tsx` -> `18 passed`


### PR DESCRIPTION
## Summary
- add cache-backed authentication failure tracking in the `users` domain
- rate-limit repeated failed logins by both client IP and normalized email and apply the same pattern to forced-reset failures
- surface the backend `RATE_LIMITED` state on the login form and add focused tests

## Testing
- `py -3.12 -m pytest tests/integration/test_auth_api.py tests/integration/test_projects_api.py` with `PYTHONPATH=D:\GitHub\project-management-system\backend\.venv\Lib\site-packages`
- `npm run test:run -- src/features/auth/AuthFlow.test.tsx src/features/projects/ProjectsFlow.test.tsx`
