### PR TITLE
Implement US-065 no public registration

### DIFF
--- a/backend/tests/integration/test_auth_api.py
+++ b/backend/tests/integration/test_auth_api.py
@@ -1250,6 +1250,21 @@ def test_current_user_requires_authentication():
     }
 
 
+def test_public_registration_endpoint_is_not_available():
+    client = APIClient()
+
+    response = client.post(
+        "/api/register",
+        {
+            "email": "public@example.com",
+            "password": "TempPassword123!",
+        },
+        format="json",
+    )
+
+    assert response.status_code == 404
+
+
 def test_current_user_rejects_inactive_authenticated_session():
     user = create_user(is_active=False)
     client = APIClient()

--- a/frontend/src/app/router/createAppRouter.tsx
+++ b/frontend/src/app/router/createAppRouter.tsx
@@ -65,6 +65,21 @@ function ResetRequiredRoute() {
   return <ResetRequiredPage user={session} />;
 }
 
+function FallbackRoute() {
+  const { session } = useSessionContext();
+
+  if (!session) {
+    return <Navigate replace to="/login" />;
+  }
+
+  return (
+    <Navigate
+      replace
+      to={session.must_reset_password ? "/reset-password" : "/"}
+    />
+  );
+}
+
 function SessionLayout() {
   return (
     <SessionGate>
@@ -80,6 +95,7 @@ function AppRoutes() {
         <Route element={<ProtectedShellRoute />} index />
         <Route element={<LoginRoute />} path="login" />
         <Route element={<ResetRequiredRoute />} path="reset-password" />
+        <Route element={<FallbackRoute />} path="*" />
       </Route>
     </Routes>
   );

--- a/frontend/src/features/auth/AuthFlow.test.tsx
+++ b/frontend/src/features/auth/AuthFlow.test.tsx
@@ -92,6 +92,8 @@ describe("auth flow", () => {
     expect(
       screen.queryByText(/session expired after inactivity/i),
     ).not.toBeInTheDocument();
+    expect(screen.queryByText(/sign up/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/create account/i)).not.toBeInTheDocument();
   });
 
   it("redirects to the reset-required shell when login returns a forced reset state", async () => {
@@ -549,5 +551,28 @@ describe("auth flow", () => {
         name: /your temporary password must be replaced/i,
       }),
     ).not.toBeInTheDocument();
+  });
+
+  it("routes unauthenticated registration-style paths back to the login flow", async () => {
+    mockFetchSequence([
+      jsonResponse({
+        status: 401,
+        body: {
+          error: {
+            code: "UNAUTHENTICATED",
+            message: "Authentication required.",
+            details: {},
+          },
+        },
+      }),
+    ]);
+
+    renderApp(["/register"]);
+
+    expect(
+      await screen.findByRole("heading", { name: /user login/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/sign up/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/create account/i)).not.toBeInTheDocument();
   });
 });

--- a/issues/stories/us-065-no-public-registration.md
+++ b/issues/stories/us-065-no-public-registration.md
@@ -1,48 +1,51 @@
-﻿# US-065 - No Public Registration  ## Metadata - Area: 21. MVP Boundary Stories - GitHub labels: `user-story`, `mvp`, `area:mvp-boundary` - Suggested status: `Backlog` - Suggested wave: `Wave 1` - Depends on: US-001 - Parallelization note: Start once dependencies are done; run in parallel with other stories in the same wave that do not share blocking dependencies.  ## User Story **As a** system owner  
+# US-065 - No Public Registration
+
+## Metadata
+
+- Area: 21. MVP Boundary Stories
+- GitHub labels: `user-story`, `mvp`, `area:mvp-boundary`
+- Suggested status: `Ready`
+- Suggested wave: `Wave 1`
+- Depends on: `US-001`
+- Parallelization note: This is a small boundary-enforcement slice on top of the auth shell.
+
+## User Story
+
+**As a** system owner  
 **I want** user creation limited to Admins  
 **So that** the internal app remains controlled.
 
-### Acceptance Criteria
+## Acceptance Criteria
 
 **Given** an unauthenticated person visits the app  
 **When** they look for sign-up  
-**Then** no public registration flow is available.  ## Implementation Breakdown **Kanban lane:** Backlog â†’ Ready â†’ Red â†’ Green â†’ Refactor â†’ Review / QA â†’ Done  
-**Definition of Done:** All listed layer tasks are complete, reviewed, tested, and traceable to the story acceptance criteria.
+**Then** no public registration flow is available.
 
-### Database
-- [ ] Confirm user fields support auth state: `is_active`, `deleted_at`, `must_reset_password`, `last_login_at`.
-- [ ] Add indexes/constraints required for email uniqueness and active-user lookup.
+## Execution Breakdown
 
-### Backend/API
-- [ ] Implement/validate session endpoint behavior and generic auth errors.
-- [ ] Enforce active, non-deleted user checks before creating sessions.
-- [ ] Add service-level handling for `must_reset_password` and allowed endpoints.
-- [ ] Emit application logs for security-relevant auth events.
+### Backend Slice
 
-### Frontend/UI
-- [ ] Build guarded route behavior for authenticated, unauthenticated, and reset-required users.
-- [ ] Display validation, generic credential, expired-session, and rate-limit states.
-- [ ] Attach CSRF tokens and credentials on unsafe requests.
+- [x] Keep user creation limited to the existing admin-only `/api/admin/users` contract.
+- [x] Add explicit backend coverage proving there is no public `/api/register` endpoint.
 
-### TDD â€” Red: Write Failing Tests First
-- [ ] Map each Given/When/Then acceptance criterion to automated tests.
-- [ ] Add happy-path tests before implementation.
-- [ ] Add validation, permission, and edge-case tests before implementation.
-- [ ] Run the tests and confirm they fail for the expected reason.
-- [ ] Unit test valid/invalid credentials, inactive users, deleted users, and reset-required users.
-- [ ] Integration test full browser/API auth flow and session expiry behavior.
+### Frontend Slice
 
-### TDD â€” Green: Implement Minimum Passing Code
-- [ ] Implement only the smallest database/backend/frontend change needed to pass the failing tests.
-- [ ] Run the story-level test set and confirm all new tests pass.
-- [ ] Confirm existing regression tests still pass.
+- [x] Keep the login page free of sign-up or create-account affordances.
+- [x] Route unknown public registration-style paths back into the existing auth flow instead of exposing a registration screen.
 
-### TDD â€” Refactor: Improve Safely
-- [ ] Refactor duplicated logic into services, validators, hooks, or shared components.
-- [ ] Confirm permissions, structured errors, soft-delete behavior, and edge cases remain covered.
-- [ ] Re-run unit, integration, and relevant frontend tests after refactoring.
+### Test Slice
 
-### Review / QA Checklist
-- [ ] Acceptance criteria from the user story are verified manually or by automated tests.
-- [ ] Structured API errors, permissions, and edge cases are validated where applicable.
-- [ ] Documentation or developer notes are updated if behavior is non-obvious.
+- [x] Add backend coverage proving `/api/register` is unavailable.
+- [x] Add frontend coverage proving unauthenticated `/register` attempts land back on the login flow.
+- [x] Add frontend coverage proving the login page does not expose sign-up UI text or actions.
+
+## Dependencies And Notes
+
+- This slice should not add a disabled registration form or placeholder sign-up page.
+- This slice should not change the admin-only create-user flow from `US-005`.
+
+## Definition Of Done
+
+- No public registration endpoint exists.
+- No public registration route or sign-up affordance exists in the frontend.
+- Unauthenticated attempts to reach a registration-style route return to the existing login flow.

--- a/skills/context/handoffs/2026-05-02-us-065-no-public-registration.md
+++ b/skills/context/handoffs/2026-05-02-us-065-no-public-registration.md
@@ -1,0 +1,13 @@
+# US-065 - No Public Registration
+
+## What Changed
+
+- Made the MVP boundary explicit instead of leaving it implicit in the current auth shell.
+- Added backend coverage proving there is no public `/api/register` endpoint.
+- Added frontend route fallback behavior so unauthenticated `/register` attempts return to the login flow.
+- Added frontend coverage proving the login screen exposes no sign-up or create-account affordance.
+
+## Validation
+
+- Backend: `py -3.12 -m pytest tests/integration/test_auth_api.py tests/integration/test_projects_api.py` with `PYTHONPATH=D:\GitHub\project-management-system\backend\.venv\Lib\site-packages` -> `61 passed`
+- Frontend: `npm run test:run -- src/features/auth/AuthFlow.test.tsx src/features/projects/ProjectsFlow.test.tsx` -> `19 passed`


### PR DESCRIPTION
## Summary
- make the no-public-registration MVP boundary explicit in routing and tests
- add backend coverage proving `/api/register` is unavailable
- route unauthenticated registration-style paths back to the existing login flow and keep sign-up affordances absent

## Testing
- `py -3.12 -m pytest tests/integration/test_auth_api.py tests/integration/test_projects_api.py` with `PYTHONPATH=D:\GitHub\project-management-system\backend\.venv\Lib\site-packages`
- `npm run test:run -- src/features/auth/AuthFlow.test.tsx src/features/projects/ProjectsFlow.test.tsx`
