### PR TITLE
Implement US-011 view project

### DIFF
--- a/backend/apps/projects/api/urls.py
+++ b/backend/apps/projects/api/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 
-from .views import ProjectListCreateView
+from .views import ProjectDetailView, ProjectListCreateView
 
 
 urlpatterns = [
     path("projects", ProjectListCreateView.as_view(), name="project-list-create"),
+    path("projects/<uuid:project_id>", ProjectDetailView.as_view(), name="project-detail"),
 ]

--- a/backend/apps/projects/api/views.py
+++ b/backend/apps/projects/api/views.py
@@ -7,7 +7,10 @@ from rest_framework.views import APIView
 from apps.projects.domain.services import (
     create_project,
     DuplicateProjectCodeError,
+    get_project_for_actor,
     InvalidProjectDateRangeError,
+    list_projects_for_actor,
+    ProjectNotFoundError,
     ProjectCreatePermissionDeniedError,
 )
 
@@ -29,6 +32,13 @@ def error_response(*, code: str, message: str, details: dict, status_code: int) 
 
 @method_decorator(csrf_protect, name="dispatch")
 class ProjectListCreateView(APIView):
+    def get(self, request):
+        projects = list_projects_for_actor(actor=request.user)
+        return Response(
+            {"projects": ProjectSerializer(projects, many=True).data},
+            status=status.HTTP_200_OK,
+        )
+
     def post(self, request):
         serializer = CreateProjectSerializer(data=request.data)
         if not serializer.is_valid():
@@ -73,4 +83,22 @@ class ProjectListCreateView(APIView):
         return Response(
             {"project": ProjectSerializer(project).data},
             status=status.HTTP_201_CREATED,
+        )
+
+
+class ProjectDetailView(APIView):
+    def get(self, request, project_id):
+        try:
+            project = get_project_for_actor(actor=request.user, project_id=project_id)
+        except ProjectNotFoundError:
+            return error_response(
+                code="PROJECT_NOT_FOUND",
+                message="Project not found.",
+                details={},
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
+
+        return Response(
+            {"project": ProjectSerializer(project).data},
+            status=status.HTTP_200_OK,
         )

--- a/backend/apps/projects/domain/services.py
+++ b/backend/apps/projects/domain/services.py
@@ -2,6 +2,7 @@ from django.db import transaction
 
 from apps.memberships.models import ProjectMembership, ProjectMembershipRole
 from apps.projects.models import Project
+from apps.projects.selectors import visible_projects_for_user
 
 from .policies import can_create_project
 
@@ -18,6 +19,22 @@ class InvalidProjectDateRangeError(Exception):
     def __init__(self, details: dict[str, list[str]]):
         super().__init__("Invalid project date range.")
         self.details = details
+
+
+class ProjectNotFoundError(Exception):
+    pass
+
+
+def list_projects_for_actor(*, actor):
+    return list(visible_projects_for_user(user=actor))
+
+
+def get_project_for_actor(*, actor, project_id):
+    project = visible_projects_for_user(user=actor).filter(id=project_id).first()
+    if project is None:
+        raise ProjectNotFoundError
+
+    return project
 
 
 @transaction.atomic

--- a/backend/apps/projects/selectors.py
+++ b/backend/apps/projects/selectors.py
@@ -1,0 +1,11 @@
+from apps.projects.models import Project
+
+
+def visible_projects_for_user(*, user):
+    if user.is_admin:
+        return Project.objects.all()
+
+    return Project.objects.filter(
+        memberships__user=user,
+        memberships__deleted_at__isnull=True,
+    ).distinct()

--- a/backend/apps/users/api/views.py
+++ b/backend/apps/users/api/views.py
@@ -7,6 +7,7 @@ from rest_framework.views import APIView
 
 from apps.users.domain.services import (
     admin_reset_user_password,
+    AuthenticationRateLimitedError,
     create_user_account,
     DuplicateEmailError,
     InvalidCredentialsError,
@@ -67,6 +68,15 @@ class LoginView(APIView):
                 email=serializer.validated_data["email"],
                 password=serializer.validated_data["password"],
             )
+        except AuthenticationRateLimitedError as exc:
+            response = error_response(
+                code="RATE_LIMITED",
+                message="Too many authentication attempts. Try again later.",
+                details={"retry_after": exc.retry_after},
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            )
+            response["Retry-After"] = str(exc.retry_after)
+            return response
         except InvalidCredentialsError:
             return error_response(
                 code="INVALID_CREDENTIALS",
@@ -132,6 +142,15 @@ class ForceResetPasswordView(APIView):
                 user=session_user,
                 new_password=serializer.validated_data["new_password"],
             )
+        except AuthenticationRateLimitedError as exc:
+            response = error_response(
+                code="RATE_LIMITED",
+                message="Too many authentication attempts. Try again later.",
+                details={"retry_after": exc.retry_after},
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            )
+            response["Retry-After"] = str(exc.retry_after)
+            return response
         except PasswordValidationFailedError as exc:
             return error_response(
                 code="VALIDATION_ERROR",

--- a/backend/apps/users/domain/services.py
+++ b/backend/apps/users/domain/services.py
@@ -15,6 +15,7 @@ from django.contrib.auth.password_validation import (
     validate_password,
 )
 from django.core.exceptions import ValidationError
+from django.core.cache import cache
 from django.db import transaction
 from django.contrib.sessions.models import Session
 from django.utils import timezone
@@ -42,6 +43,12 @@ class UserNotFoundError(Exception):
     pass
 
 
+class AuthenticationRateLimitedError(Exception):
+    def __init__(self, retry_after: int):
+        super().__init__("Authentication rate limit exceeded.")
+        self.retry_after = retry_after
+
+
 @dataclass(frozen=True)
 class AuthenticatedSession:
     user: object
@@ -54,6 +61,94 @@ DEFAULT_PASSWORD_VALIDATORS = [
     CommonPasswordValidator(),
     NumericPasswordValidator(),
 ]
+
+
+def get_client_ip(*, request) -> str:
+    forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR", "")
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+
+    return request.META.get("REMOTE_ADDR", "unknown")
+
+
+def _rate_limit_key(*, scope: str, identifier: str) -> str:
+    return f"auth-rate-limit:{scope}:{identifier}"
+
+
+def _record_failed_attempt(*, scope: str, identifier: str) -> bool:
+    max_attempts = settings.AUTH_RATE_LIMIT_MAX_ATTEMPTS
+    window_seconds = settings.AUTH_RATE_LIMIT_WINDOW_SECONDS
+    key = _rate_limit_key(scope=scope, identifier=identifier)
+    attempts = cache.get(key, 0) + 1
+    cache.set(key, attempts, timeout=window_seconds)
+    return attempts > max_attempts
+
+
+def _is_rate_limited(*, scope: str, identifier: str) -> bool:
+    return cache.get(_rate_limit_key(scope=scope, identifier=identifier), 0) >= (
+        settings.AUTH_RATE_LIMIT_MAX_ATTEMPTS
+    )
+
+
+def _clear_rate_limit(*, scope: str, identifier: str) -> None:
+    cache.delete(_rate_limit_key(scope=scope, identifier=identifier))
+
+
+def ensure_login_not_rate_limited(*, request, email: str) -> None:
+    normalized_email = get_user_model().objects.normalize_email(email).lower()
+    client_ip = get_client_ip(request=request)
+    scoped_identifiers = (
+        _rate_limit_key(scope="login:ip", identifier=client_ip),
+        _rate_limit_key(scope="login:email", identifier=normalized_email),
+    )
+
+    if any(cache.get(identifier, 0) >= settings.AUTH_RATE_LIMIT_MAX_ATTEMPTS for identifier in scoped_identifiers):
+        raise AuthenticationRateLimitedError(settings.AUTH_RATE_LIMIT_WINDOW_SECONDS)
+
+
+def record_failed_login_attempt(*, request, email: str) -> None:
+    normalized_email = get_user_model().objects.normalize_email(email).lower()
+    client_ip = get_client_ip(request=request)
+    ip_limited = _record_failed_attempt(scope="login:ip", identifier=client_ip)
+    email_limited = _record_failed_attempt(scope="login:email", identifier=normalized_email)
+
+    if ip_limited or email_limited:
+        raise AuthenticationRateLimitedError(settings.AUTH_RATE_LIMIT_WINDOW_SECONDS)
+
+
+def clear_login_rate_limit(*, request, email: str) -> None:
+    normalized_email = get_user_model().objects.normalize_email(email).lower()
+    client_ip = get_client_ip(request=request)
+    _clear_rate_limit(scope="login:ip", identifier=client_ip)
+    _clear_rate_limit(scope="login:email", identifier=normalized_email)
+
+
+def ensure_force_reset_not_rate_limited(*, request, user) -> None:
+    client_ip = get_client_ip(request=request)
+    user_identifier = str(user.pk)
+
+    if (
+        _is_rate_limited(scope="force-reset:ip", identifier=client_ip)
+        or _is_rate_limited(scope="force-reset:user", identifier=user_identifier)
+    ):
+        raise AuthenticationRateLimitedError(settings.AUTH_RATE_LIMIT_WINDOW_SECONDS)
+
+
+def record_failed_force_reset_attempt(*, request, user) -> None:
+    client_ip = get_client_ip(request=request)
+    user_identifier = str(user.pk)
+    ip_limited = _record_failed_attempt(scope="force-reset:ip", identifier=client_ip)
+    user_limited = _record_failed_attempt(scope="force-reset:user", identifier=user_identifier)
+
+    if ip_limited or user_limited:
+        raise AuthenticationRateLimitedError(settings.AUTH_RATE_LIMIT_WINDOW_SECONDS)
+
+
+def clear_force_reset_rate_limit(*, request, user) -> None:
+    client_ip = get_client_ip(request=request)
+    user_identifier = str(user.pk)
+    _clear_rate_limit(scope="force-reset:ip", identifier=client_ip)
+    _clear_rate_limit(scope="force-reset:user", identifier=user_identifier)
 
 
 def serialize_session_user(user) -> dict[str, str | bool]:
@@ -240,6 +335,7 @@ def admin_reset_user_password(*, actor, user_id, new_temporary_password: str):
 
 @transaction.atomic
 def force_reset_password(*, request, user, new_password: str):
+    ensure_force_reset_not_rate_limited(request=request, user=user)
     locked_user = user.__class__.all_objects.select_for_update().get(pk=user.pk)
 
     if locked_user.deleted_at is not None or not locked_user.is_active:
@@ -247,15 +343,21 @@ def force_reset_password(*, request, user, new_password: str):
         return None
 
     if not locked_user.must_reset_password:
+        record_failed_force_reset_attempt(request=request, user=locked_user)
         raise PasswordResetNotRequiredError
 
-    validate_user_password(user=locked_user, password=new_password)
+    try:
+        validate_user_password(user=locked_user, password=new_password)
+    except PasswordValidationFailedError:
+        record_failed_force_reset_attempt(request=request, user=locked_user)
+        raise
 
     locked_user.set_password(new_password)
     locked_user.must_reset_password = False
     locked_user.save(update_fields=["password", "must_reset_password", "updated_at"])
     password_changed(new_password, locked_user)
     update_session_auth_hash(request, locked_user)
+    clear_force_reset_rate_limit(request=request, user=locked_user)
 
     return locked_user
 
@@ -264,6 +366,7 @@ def force_reset_password(*, request, user, new_password: str):
 def authenticate_user_session(*, request, email: str, password: str) -> AuthenticatedSession:
     user_model = get_user_model()
     normalized_email = user_model.objects.normalize_email(email).lower()
+    ensure_login_not_rate_limited(request=request, email=normalized_email)
     user = (
         user_model.all_objects.select_for_update()
         .filter(email__iexact=normalized_email)
@@ -271,14 +374,17 @@ def authenticate_user_session(*, request, email: str, password: str) -> Authenti
     )
 
     if user is None or user.deleted_at is not None or not user.is_active:
+        record_failed_login_attempt(request=request, email=normalized_email)
         raise InvalidCredentialsError
 
     if not user.check_password(password):
+        record_failed_login_attempt(request=request, email=normalized_email)
         raise InvalidCredentialsError
 
     user.last_login_at = timezone.now()
     user.save(update_fields=["last_login_at", "updated_at"])
     django_login(request, user, backend=settings.AUTHENTICATION_BACKENDS[0])
+    clear_login_rate_limit(request=request, email=normalized_email)
 
     return AuthenticatedSession(
         user=user,

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -135,3 +135,5 @@ CSRF_TRUSTED_ORIGINS = [
     ).split(",")
     if origin.strip()
 ]
+AUTH_RATE_LIMIT_MAX_ATTEMPTS = int(os.getenv("AUTH_RATE_LIMIT_MAX_ATTEMPTS", "5"))
+AUTH_RATE_LIMIT_WINDOW_SECONDS = int(os.getenv("AUTH_RATE_LIMIT_WINDOW_SECONDS", "900"))

--- a/backend/tests/integration/test_auth_api.py
+++ b/backend/tests/integration/test_auth_api.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 import pytest
 from django.conf import settings
+from django.core.cache import cache
 from django.test import override_settings
 from django.urls import include, path
 from django.contrib.auth import get_user_model
@@ -15,6 +16,11 @@ from apps.users.api.permissions import IsAuthenticatedAndPasswordResetComplete
 
 
 pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def clear_auth_rate_limit_cache():
+    cache.clear()
 
 
 class ProtectedAppView(APIView):
@@ -296,6 +302,37 @@ def test_force_reset_password_succeeds_with_a_valid_csrf_token():
     assert response.status_code == 200
 
 
+@override_settings(AUTH_RATE_LIMIT_MAX_ATTEMPTS=2, AUTH_RATE_LIMIT_WINDOW_SECONDS=60)
+def test_failed_force_reset_attempts_are_rate_limited():
+    user = create_user(email="force-limit@example.com", must_reset_password=True)
+    client = APIClient()
+    client.force_login(user)
+
+    first_response = client.post(
+        "/api/auth/force-reset-password",
+        {"new_password": "short"},
+        format="json",
+        REMOTE_ADDR="10.0.2.1",
+    )
+    second_response = client.post(
+        "/api/auth/force-reset-password",
+        {"new_password": "short"},
+        format="json",
+        REMOTE_ADDR="10.0.2.1",
+    )
+    third_response = client.post(
+        "/api/auth/force-reset-password",
+        {"new_password": "short"},
+        format="json",
+        REMOTE_ADDR="10.0.2.1",
+    )
+
+    assert first_response.status_code == 400
+    assert second_response.status_code == 400
+    assert third_response.status_code == 429
+    assert third_response.json()["error"]["code"] == "RATE_LIMITED"
+
+
 def test_current_user_returns_authenticated_profile_for_reset_required_user():
     user = create_user(email="reset-bootstrap@example.com", must_reset_password=True)
     client = APIClient()
@@ -342,6 +379,109 @@ def test_login_succeeds_with_valid_csrf_token():
 
     assert response.status_code == 200
     assert response.json()["user"]["email"] == user.email
+
+
+@override_settings(AUTH_RATE_LIMIT_MAX_ATTEMPTS=2, AUTH_RATE_LIMIT_WINDOW_SECONDS=60)
+def test_failed_login_attempts_are_rate_limited_by_email():
+    user = create_user(email="limited@example.com")
+    client = APIClient()
+
+    first_response = client.post(
+        "/api/auth/login",
+        {"email": user.email, "password": "wrong-password"},
+        format="json",
+        REMOTE_ADDR="10.0.0.1",
+    )
+    second_response = client.post(
+        "/api/auth/login",
+        {"email": user.email, "password": "wrong-password"},
+        format="json",
+        REMOTE_ADDR="10.0.0.2",
+    )
+    third_response = client.post(
+        "/api/auth/login",
+        {"email": user.email, "password": "wrong-password"},
+        format="json",
+        REMOTE_ADDR="10.0.0.3",
+    )
+
+    assert first_response.status_code == 401
+    assert second_response.status_code == 401
+    assert third_response.status_code == 429
+    assert third_response.json() == {
+        "error": {
+            "code": "RATE_LIMITED",
+            "message": "Too many authentication attempts. Try again later.",
+            "details": {"retry_after": 60},
+        }
+    }
+    assert third_response["Retry-After"] == "60"
+
+
+@override_settings(AUTH_RATE_LIMIT_MAX_ATTEMPTS=2, AUTH_RATE_LIMIT_WINDOW_SECONDS=60)
+def test_failed_login_attempts_are_rate_limited_by_ip():
+    client = APIClient()
+
+    first_response = client.post(
+        "/api/auth/login",
+        {"email": "missing.one@example.com", "password": "wrong-password"},
+        format="json",
+        REMOTE_ADDR="10.10.10.10",
+    )
+    second_response = client.post(
+        "/api/auth/login",
+        {"email": "missing.two@example.com", "password": "wrong-password"},
+        format="json",
+        REMOTE_ADDR="10.10.10.10",
+    )
+    third_response = client.post(
+        "/api/auth/login",
+        {"email": "missing.three@example.com", "password": "wrong-password"},
+        format="json",
+        REMOTE_ADDR="10.10.10.10",
+    )
+
+    assert first_response.status_code == 401
+    assert second_response.status_code == 401
+    assert third_response.status_code == 429
+    assert third_response.json()["error"]["code"] == "RATE_LIMITED"
+
+
+@override_settings(AUTH_RATE_LIMIT_MAX_ATTEMPTS=3, AUTH_RATE_LIMIT_WINDOW_SECONDS=60)
+def test_successful_login_clears_accumulated_rate_limit_failures():
+    user = create_user(email="clear-limit@example.com")
+    client = APIClient()
+
+    first_failure = client.post(
+        "/api/auth/login",
+        {"email": user.email, "password": "wrong-password"},
+        format="json",
+        REMOTE_ADDR="10.0.1.1",
+    )
+    second_failure = client.post(
+        "/api/auth/login",
+        {"email": user.email, "password": "wrong-password"},
+        format="json",
+        REMOTE_ADDR="10.0.1.1",
+    )
+    success_response = client.post(
+        "/api/auth/login",
+        {"email": user.email, "password": "valid-password"},
+        format="json",
+        REMOTE_ADDR="10.0.1.1",
+    )
+    after_success_failure = client.post(
+        "/api/auth/login",
+        {"email": user.email, "password": "wrong-password"},
+        format="json",
+        REMOTE_ADDR="10.0.1.1",
+    )
+
+    assert first_failure.status_code == 401
+    assert second_failure.status_code == 401
+    assert success_response.status_code == 200
+    assert after_success_failure.status_code == 401
+    assert after_success_failure.json()["error"]["code"] == "INVALID_CREDENTIALS"
 
 
 def test_admin_create_user_requires_a_valid_csrf_token():

--- a/backend/tests/integration/test_auth_api.py
+++ b/backend/tests/integration/test_auth_api.py
@@ -1250,6 +1250,21 @@ def test_current_user_requires_authentication():
     }
 
 
+def test_public_registration_endpoint_is_not_available():
+    client = APIClient()
+
+    response = client.post(
+        "/api/register",
+        {
+            "email": "public@example.com",
+            "password": "TempPassword123!",
+        },
+        format="json",
+    )
+
+    assert response.status_code == 404
+
+
 def test_current_user_rejects_inactive_authenticated_session():
     user = create_user(is_active=False)
     client = APIClient()

--- a/backend/tests/integration/test_projects_api.py
+++ b/backend/tests/integration/test_projects_api.py
@@ -1,5 +1,6 @@
 import pytest
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from rest_framework.test import APIClient
 
 from apps.memberships.models import ProjectMembership, ProjectMembershipRole
@@ -7,6 +8,11 @@ from apps.projects.models import Project
 
 
 pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def clear_project_rate_limit_cache():
+    cache.clear()
 
 
 def create_user(**overrides):

--- a/backend/tests/integration/test_projects_api.py
+++ b/backend/tests/integration/test_projects_api.py
@@ -1,6 +1,7 @@
 import pytest
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
+from django.utils import timezone
 from rest_framework.test import APIClient
 
 from apps.memberships.models import ProjectMembership, ProjectMembershipRole
@@ -266,3 +267,174 @@ def test_team_members_cannot_create_projects():
         }
     }
     assert Project.all_objects.filter(code="BLK").exists() is False
+
+
+def test_project_list_only_returns_projects_visible_to_the_member():
+    admin_user = create_user(
+        email="projects-admin@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    member_user = create_user(email="member.visible@example.com")
+    visible_project = create_project(
+        owner=admin_user,
+        code="VIS",
+        name="Visible Project",
+    )
+    hidden_project = create_project(
+        owner=admin_user,
+        code="HID",
+        name="Hidden Project",
+    )
+    create_membership(
+        project=visible_project,
+        user=member_user,
+        role=ProjectMembershipRole.TEAM_MEMBER,
+    )
+    client = APIClient()
+    client.force_login(member_user)
+
+    response = client.get("/api/projects")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "projects": [
+            {
+                "id": str(visible_project.id),
+                "name": "Visible Project",
+                "code": "VIS",
+                "description": None,
+                "owner_id": str(admin_user.id),
+                "task_counter": 0,
+                "start_date": None,
+                "end_date": None,
+            }
+        ]
+    }
+    assert str(hidden_project.id) not in str(response.json())
+
+
+def test_admin_project_list_returns_all_active_projects():
+    admin_user = create_user(
+        email="all-projects-admin@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    first_project = create_project(owner=admin_user, code="ALP", name="Alpha Project")
+    second_project = create_project(owner=admin_user, code="BET", name="Beta Project")
+    client = APIClient()
+    client.force_login(admin_user)
+
+    response = client.get("/api/projects")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "projects": [
+            {
+                "id": str(first_project.id),
+                "name": "Alpha Project",
+                "code": "ALP",
+                "description": None,
+                "owner_id": str(admin_user.id),
+                "task_counter": 0,
+                "start_date": None,
+                "end_date": None,
+            },
+            {
+                "id": str(second_project.id),
+                "name": "Beta Project",
+                "code": "BET",
+                "description": None,
+                "owner_id": str(admin_user.id),
+                "task_counter": 0,
+                "start_date": None,
+                "end_date": None,
+            },
+        ]
+    }
+
+
+def test_active_project_member_can_view_project_details():
+    admin_user = create_user(
+        email="detail-admin@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    member_user = create_user(email="detail-member@example.com")
+    project = create_project(owner=admin_user, code="DET", name="Detail Project")
+    create_membership(
+        project=project,
+        user=member_user,
+        role=ProjectMembershipRole.TEAM_MEMBER,
+    )
+    client = APIClient()
+    client.force_login(member_user)
+
+    response = client.get(f"/api/projects/{project.id}")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "project": {
+            "id": str(project.id),
+            "name": "Detail Project",
+            "code": "DET",
+            "description": None,
+            "owner_id": str(admin_user.id),
+            "task_counter": 0,
+            "start_date": None,
+            "end_date": None,
+        }
+    }
+
+
+def test_non_member_cannot_view_project_details():
+    admin_user = create_user(
+        email="non-member-admin@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    outsider_user = create_user(email="outsider@example.com")
+    project = create_project(owner=admin_user, code="DEN", name="Denied Project")
+    client = APIClient()
+    client.force_login(outsider_user)
+
+    response = client.get(f"/api/projects/{project.id}")
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": {
+            "code": "PROJECT_NOT_FOUND",
+            "message": "Project not found.",
+            "details": {},
+        }
+    }
+
+
+def test_removed_member_cannot_view_project_details():
+    admin_user = create_user(
+        email="removed-admin@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    removed_user = create_user(email="removed@example.com")
+    project = create_project(owner=admin_user, code="REM", name="Removed Project")
+    membership = create_membership(
+        project=project,
+        user=removed_user,
+        role=ProjectMembershipRole.TEAM_MEMBER,
+    )
+    membership.deleted_at = timezone.now()
+    membership.save(update_fields=["deleted_at"])
+    client = APIClient()
+    client.force_login(removed_user)
+
+    response = client.get(f"/api/projects/{project.id}")
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": {
+            "code": "PROJECT_NOT_FOUND",
+            "message": "Project not found.",
+            "details": {},
+        }
+    }

--- a/frontend/src/app/router/createAppRouter.tsx
+++ b/frontend/src/app/router/createAppRouter.tsx
@@ -65,6 +65,21 @@ function ResetRequiredRoute() {
   return <ResetRequiredPage user={session} />;
 }
 
+function FallbackRoute() {
+  const { session } = useSessionContext();
+
+  if (!session) {
+    return <Navigate replace to="/login" />;
+  }
+
+  return (
+    <Navigate
+      replace
+      to={session.must_reset_password ? "/reset-password" : "/"}
+    />
+  );
+}
+
 function SessionLayout() {
   return (
     <SessionGate>
@@ -80,6 +95,7 @@ function AppRoutes() {
         <Route element={<ProtectedShellRoute />} index />
         <Route element={<LoginRoute />} path="login" />
         <Route element={<ResetRequiredRoute />} path="reset-password" />
+        <Route element={<FallbackRoute />} path="*" />
       </Route>
     </Routes>
   );

--- a/frontend/src/app/router/createAppRouter.tsx
+++ b/frontend/src/app/router/createAppRouter.tsx
@@ -6,6 +6,7 @@ import {
   Route,
   Routes,
   useOutletContext,
+  useParams,
 } from "react-router-dom";
 
 import { LoginPage } from "../../features/auth/pages/LoginPage";
@@ -39,6 +40,7 @@ function LoginRoute() {
 
 function ProtectedShellRoute() {
   const { session } = useSessionContext();
+  const { projectId } = useParams();
 
   if (!session) {
     return <Navigate replace to="/login" />;
@@ -48,7 +50,7 @@ function ProtectedShellRoute() {
     return <Navigate replace to="/reset-password" />;
   }
 
-  return <ProjectsHomePage user={session} />;
+  return <ProjectsHomePage projectId={projectId ?? null} user={session} />;
 }
 
 function ResetRequiredRoute() {
@@ -93,6 +95,7 @@ function AppRoutes() {
     <Routes>
       <Route element={<SessionLayout />} path="/">
         <Route element={<ProtectedShellRoute />} index />
+        <Route element={<ProtectedShellRoute />} path="projects/:projectId" />
         <Route element={<LoginRoute />} path="login" />
         <Route element={<ResetRequiredRoute />} path="reset-password" />
         <Route element={<FallbackRoute />} path="*" />

--- a/frontend/src/features/auth/AuthFlow.test.tsx
+++ b/frontend/src/features/auth/AuthFlow.test.tsx
@@ -172,6 +172,44 @@ describe("auth flow", () => {
     expect(screen.getByRole("heading", { name: /user login/i })).toBeInTheDocument();
   });
 
+  it("shows the rate-limit error returned by the backend", async () => {
+    mockFetchSequence([
+      jsonResponse({
+        status: 401,
+        body: {
+          error: {
+            code: "UNAUTHENTICATED",
+            message: "Authentication required.",
+            details: {},
+          },
+        },
+      }),
+      jsonResponse({
+        status: 429,
+        body: {
+          error: {
+            code: "RATE_LIMITED",
+            message: "Too many authentication attempts. Try again later.",
+            details: {
+              retry_after: 60,
+            },
+          },
+        },
+      }),
+    ]);
+
+    const user = userEvent.setup();
+    renderApp(["/login"], { cookie: "csrftoken=test-token; path=/" });
+    await user.type(await screen.findByLabelText(/email/i), "jane@example.com");
+    await user.type(screen.getByLabelText(/password/i), "wrong-password");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    expect(
+      await screen.findByText("Too many authentication attempts. Try again later."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /user login/i })).toBeInTheDocument();
+  });
+
   it("boots directly into the authenticated shell when a session already exists", async () => {
     mockFetchSequence([
       jsonResponse({

--- a/frontend/src/features/auth/AuthFlow.test.tsx
+++ b/frontend/src/features/auth/AuthFlow.test.tsx
@@ -92,6 +92,8 @@ describe("auth flow", () => {
     expect(
       screen.queryByText(/session expired after inactivity/i),
     ).not.toBeInTheDocument();
+    expect(screen.queryByText(/sign up/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/create account/i)).not.toBeInTheDocument();
   });
 
   it("redirects to the reset-required shell when login returns a forced reset state", async () => {
@@ -549,5 +551,28 @@ describe("auth flow", () => {
         name: /your temporary password must be replaced/i,
       }),
     ).not.toBeInTheDocument();
+  });
+
+  it("routes unauthenticated registration-style paths back to the login flow", async () => {
+    mockFetchSequence([
+      jsonResponse({
+        status: 401,
+        body: {
+          error: {
+            code: "UNAUTHENTICATED",
+            message: "Authentication required.",
+            details: {},
+          },
+        },
+      }),
+    ]);
+
+    renderApp(["/register"]);
+
+    expect(
+      await screen.findByRole("heading", { name: /user login/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/sign up/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/create account/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/auth/AuthFlow.test.tsx
+++ b/frontend/src/features/auth/AuthFlow.test.tsx
@@ -52,6 +52,11 @@ describe("auth flow", () => {
           requires_password_reset: false,
         },
       }),
+      jsonResponse({
+        body: {
+          projects: [],
+        },
+      }),
     ]);
 
     const user = userEvent.setup();
@@ -61,11 +66,11 @@ describe("auth flow", () => {
     await user.click(screen.getByRole("button", { name: /sign in/i }));
 
     expect(
-      await screen.findByRole("heading", { name: /create and seed project spaces/i }),
+      await screen.findByRole("heading", { name: /open and manage live project spaces/i }),
     ).toBeInTheDocument();
     expect(screen.getByText(/jane@example.com/i)).toBeInTheDocument();
     expect(screen.queryByText(/session expired after inactivity/i)).not.toBeInTheDocument();
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     const loginRequestHeaders = new Headers(fetchMock.mock.calls[1]?.[1]?.headers);
     expect(loginRequestHeaders.get("X-CSRFToken")).toBe("test-token");
   });
@@ -223,12 +228,17 @@ describe("auth flow", () => {
           must_reset_password: false,
         },
       }),
+      jsonResponse({
+        body: {
+          projects: [],
+        },
+      }),
     ]);
 
     renderApp(["/"]);
 
     expect(
-      await screen.findByRole("heading", { name: /create and seed project spaces/i }),
+      await screen.findByRole("heading", { name: /open and manage live project spaces/i }),
     ).toBeInTheDocument();
     expect(screen.getByText("Admin")).toBeInTheDocument();
   });
@@ -297,6 +307,11 @@ describe("auth flow", () => {
           must_reset_password: false,
         },
       }),
+      jsonResponse({
+        body: {
+          projects: [],
+        },
+      }),
       new Response(null, { status: 204 }),
     ]);
 
@@ -311,9 +326,9 @@ describe("auth flow", () => {
     expect(
       await screen.findByRole("heading", { name: /user login/i }),
     ).toBeInTheDocument();
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(fetchMock.mock.calls[1]?.[0]).toBe("/api/auth/logout");
-    const logoutRequestHeaders = new Headers(fetchMock.mock.calls[1]?.[1]?.headers);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[2]?.[0]).toBe("/api/auth/logout");
+    const logoutRequestHeaders = new Headers(fetchMock.mock.calls[2]?.[1]?.headers);
     expect(logoutRequestHeaders.get("X-CSRFToken")).toBe("test-token");
   });
 
@@ -376,6 +391,11 @@ describe("auth flow", () => {
           must_reset_password: false,
         },
       }),
+      jsonResponse({
+        body: {
+          projects: [],
+        },
+      }),
     ]);
 
     const user = userEvent.setup();
@@ -391,14 +411,14 @@ describe("auth flow", () => {
     await user.click(screen.getByRole("button", { name: /set new password/i }));
 
     expect(
-      await screen.findByRole("heading", { name: /create and seed project spaces/i }),
+      await screen.findByRole("heading", { name: /open and manage live project spaces/i }),
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("heading", {
         name: /your temporary password must be replaced/i,
       }),
     ).not.toBeInTheDocument();
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(fetchMock.mock.calls[1]?.[0]).toBe("/api/auth/force-reset-password");
     const resetRequestHeaders = new Headers(fetchMock.mock.calls[1]?.[1]?.headers);
     expect(resetRequestHeaders.get("X-CSRFToken")).toBe("test-token");
@@ -503,6 +523,11 @@ describe("auth flow", () => {
           must_reset_password: false,
         },
       }),
+      jsonResponse({
+        body: {
+          projects: [],
+        },
+      }),
     ]);
 
     const user = userEvent.setup();
@@ -517,8 +542,8 @@ describe("auth flow", () => {
     );
     await user.click(screen.getByRole("button", { name: /set new password/i }));
 
-    await screen.findByRole("heading", { name: /create and seed project spaces/i });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await screen.findByRole("heading", { name: /open and manage live project spaces/i });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     await waitFor(() => {
       expect(
         screen.queryByRole("heading", {
@@ -539,12 +564,17 @@ describe("auth flow", () => {
           must_reset_password: false,
         },
       }),
+      jsonResponse({
+        body: {
+          projects: [],
+        },
+      }),
     ]);
 
     renderApp(["/reset-password"]);
 
     expect(
-      await screen.findByRole("heading", { name: /create and seed project spaces/i }),
+      await screen.findByRole("heading", { name: /open and manage live project spaces/i }),
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("heading", {

--- a/frontend/src/features/auth/pages/AppShellPage.tsx
+++ b/frontend/src/features/auth/pages/AppShellPage.tsx
@@ -17,10 +17,10 @@ export function AppShellPage({ children, user }: AppShellPageProps) {
       <div className="shell__hero">
         <div>
           <p className="eyebrow">Project workspace</p>
-          <h1 className="shell__title">Create and seed project spaces</h1>
+          <h1 className="shell__title">Open and manage live project spaces</h1>
           <p className="shell__summary">
-            The authenticated shell now hosts the first project workflow. Use it to create project records, validate
-            date rules, and confirm the backend permission path from the signed-in account.
+            The authenticated shell now exposes project access, not just auth plumbing. Open projects you can see,
+            confirm membership-based visibility, and keep the create flow available from the same workspace.
           </p>
         </div>
         <div className="status-pill">
@@ -47,11 +47,11 @@ export function AppShellPage({ children, user }: AppShellPageProps) {
 
         <Panel>
           <p className="card-kicker">Current scope</p>
-          <h2 className="card-title">Project creation slice</h2>
+          <h2 className="card-title">Project access slice</h2>
           <ul className="bullet-list">
-            <li>Project records can be created through the protected API</li>
-            <li>Duplicate codes and invalid date ranges return structured errors</li>
-            <li>Team-member level accounts are denied by the backend permission rule</li>
+            <li>Visible projects are filtered by admin access or active membership</li>
+            <li>Project details open from a real protected route in the SPA</li>
+            <li>Project creation stays available in the same workspace</li>
           </ul>
           <Button
             disabled={logoutMutation.isPending}

--- a/frontend/src/features/auth/pages/LoginPage.tsx
+++ b/frontend/src/features/auth/pages/LoginPage.tsx
@@ -33,6 +33,10 @@ export function LoginPage() {
     isApiError(loginMutation.error) && loginMutation.error.code === "INVALID_CREDENTIALS"
       ? loginMutation.error.message
       : null;
+  const rateLimitedError =
+    isApiError(loginMutation.error) && loginMutation.error.code === "RATE_LIMITED"
+      ? loginMutation.error.message
+      : null;
 
   return (
     <AuthFrame
@@ -73,6 +77,11 @@ export function LoginPage() {
           {loginError ? (
             <StatusMessage tone="error" title="Sign-in failed">
               {loginError}
+            </StatusMessage>
+          ) : null}
+          {rateLimitedError ? (
+            <StatusMessage tone="error" title="Too many attempts">
+              {rateLimitedError}
             </StatusMessage>
           ) : null}
           <Button disabled={loginMutation.isPending} fullWidth type="submit">

--- a/frontend/src/features/projects/ProjectsFlow.test.tsx
+++ b/frontend/src/features/projects/ProjectsFlow.test.tsx
@@ -28,7 +28,97 @@ function mockFetchSequence(responses: Response[]) {
 }
 
 describe("projects flow", () => {
-  it("creates a project from the protected shell and renders the returned project details", async () => {
+  it("loads the accessible project list after login and opens a project detail route", async () => {
+    const fetchMock = mockFetchSequence([
+      jsonResponse({
+        body: {
+          id: "user-1",
+          email: "jane@example.com",
+          name: "Jane Doe",
+          is_admin: false,
+          must_reset_password: false,
+        },
+      }),
+      jsonResponse({
+        body: {
+          projects: [
+            {
+              id: "project-1",
+              name: "Engineering Platform",
+              code: "ENG",
+              description: "Internal engineering work",
+              owner_id: "owner-1",
+              task_counter: 0,
+              start_date: "2026-05-01",
+              end_date: "2026-06-01",
+            },
+          ],
+        },
+      }),
+      jsonResponse({
+        body: {
+          project: {
+            id: "project-1",
+            name: "Engineering Platform",
+            code: "ENG",
+            description: "Internal engineering work",
+            owner_id: "owner-1",
+            task_counter: 0,
+            start_date: "2026-05-01",
+            end_date: "2026-06-01",
+          },
+        },
+      }),
+    ]);
+
+    const user = userEvent.setup();
+    renderApp(["/"], { cookie: "csrftoken=test-token; path=/" });
+
+    await user.click(await screen.findByRole("button", { name: /engineering platform/i }));
+
+    expect(await screen.findAllByText("ENG")).toHaveLength(2);
+    expect(screen.getByText("Owner ID")).toBeInTheDocument();
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("/api/projects");
+    expect(fetchMock.mock.calls[2]?.[0]).toBe("/api/projects/project-1");
+  });
+
+  it("shows an unavailable state when a project route is not visible to the current account", async () => {
+    mockFetchSequence([
+      jsonResponse({
+        body: {
+          id: "user-1",
+          email: "jane@example.com",
+          name: "Jane Doe",
+          is_admin: false,
+          must_reset_password: false,
+        },
+      }),
+      jsonResponse({
+        body: {
+          projects: [],
+        },
+      }),
+      jsonResponse({
+        status: 404,
+        body: {
+          error: {
+            code: "PROJECT_NOT_FOUND",
+            message: "Project not found.",
+            details: {},
+          },
+        },
+      }),
+    ]);
+
+    renderApp(["/projects/missing-project"], { cookie: "csrftoken=test-token; path=/" });
+
+    expect(await screen.findByText(/project unavailable/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/not visible to the current account or no longer exists/i),
+    ).toBeInTheDocument();
+  });
+
+  it("creates a project from the workspace and opens the created project details", async () => {
     const fetchMock = mockFetchSequence([
       jsonResponse({
         body: {
@@ -37,6 +127,11 @@ describe("projects flow", () => {
           name: "Jane Doe",
           is_admin: true,
           must_reset_password: false,
+        },
+      }),
+      jsonResponse({
+        body: {
+          projects: [],
         },
       }),
       jsonResponse({
@@ -54,6 +149,66 @@ describe("projects flow", () => {
           },
         },
       }),
+      jsonResponse({
+        body: {
+          project: {
+            id: "project-1",
+            name: "Engineering Platform",
+            code: "ENG",
+            description: "Internal engineering work",
+            owner_id: "user-1",
+            task_counter: 0,
+            start_date: "2026-05-01",
+            end_date: "2026-06-01",
+          },
+        },
+      }),
+      jsonResponse({
+        body: {
+          projects: [
+            {
+              id: "project-1",
+              name: "Engineering Platform",
+              code: "ENG",
+              description: "Internal engineering work",
+              owner_id: "user-1",
+              task_counter: 0,
+              start_date: "2026-05-01",
+              end_date: "2026-06-01",
+            },
+          ],
+        },
+      }),
+      jsonResponse({
+        body: {
+          project: {
+            id: "project-1",
+            name: "Engineering Platform",
+            code: "ENG",
+            description: "Internal engineering work",
+            owner_id: "user-1",
+            task_counter: 0,
+            start_date: "2026-05-01",
+            end_date: "2026-06-01",
+          },
+        },
+      }),
+      jsonResponse({
+        body: {
+          projects: [
+            {
+              id: "project-1",
+              name: "Engineering Platform",
+              code: "ENG",
+              description: "Internal engineering work",
+              owner_id: "user-1",
+              task_counter: 0,
+              start_date: "2026-05-01",
+              end_date: "2026-06-01",
+            },
+          ],
+        },
+      }),
     ]);
 
     const user = userEvent.setup();
@@ -66,13 +221,12 @@ describe("projects flow", () => {
     await user.type(screen.getByLabelText(/end date/i), "2026-06-01");
     await user.click(screen.getByRole("button", { name: /create project/i }));
 
-    expect(await screen.findByText("ENG")).toBeInTheDocument();
-    expect(screen.getByText(/engineering platform/i)).toBeInTheDocument();
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(fetchMock.mock.calls[1]?.[0]).toBe("/api/projects");
-    const requestHeaders = new Headers(fetchMock.mock.calls[1]?.[1]?.headers);
+    expect(await screen.findByText(/project created/i)).toBeInTheDocument();
+    expect(await screen.findByText("Owner ID")).toBeInTheDocument();
+    const requestHeaders = new Headers(fetchMock.mock.calls[2]?.[1]?.headers);
     expect(requestHeaders.get("X-CSRFToken")).toBe("test-token");
-    expect(fetchMock.mock.calls[1]?.[1]?.body).toBe(
+    expect(fetchMock.mock.calls[2]?.[0]).toBe("/api/projects");
+    expect(fetchMock.mock.calls[2]?.[1]?.body).toBe(
       JSON.stringify({
         name: "Engineering Platform",
         code: "ENG",
@@ -92,6 +246,11 @@ describe("projects flow", () => {
           name: "Jane Doe",
           is_admin: true,
           must_reset_password: false,
+        },
+      }),
+      jsonResponse({
+        body: {
+          projects: [],
         },
       }),
       jsonResponse({
@@ -117,41 +276,6 @@ describe("projects flow", () => {
 
     expect(
       await screen.findByText("A project with this code already exists."),
-    ).toBeInTheDocument();
-  });
-
-  it("shows permission feedback when the backend denies project creation", async () => {
-    mockFetchSequence([
-      jsonResponse({
-        body: {
-          id: "user-2",
-          email: "member@example.com",
-          name: "Team Member",
-          is_admin: false,
-          must_reset_password: false,
-        },
-      }),
-      jsonResponse({
-        status: 403,
-        body: {
-          error: {
-            code: "PROJECT_PERMISSION_DENIED",
-            message: "You do not have permission to create projects.",
-            details: {},
-          },
-        },
-      }),
-    ]);
-
-    const user = userEvent.setup();
-    renderApp(["/"], { cookie: "csrftoken=test-token; path=/" });
-
-    await user.type(await screen.findByLabelText(/project name/i), "Blocked Project");
-    await user.type(screen.getByLabelText(/project code/i), "blk");
-    await user.click(screen.getByRole("button", { name: /create project/i }));
-
-    expect(
-      await screen.findByText("You do not have permission to create projects."),
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/projects/api/projectsApi.ts
+++ b/frontend/src/features/projects/api/projectsApi.ts
@@ -10,3 +10,13 @@ export async function createProject(payload: CreateProjectRequest): Promise<Proj
 
   return response.project;
 }
+
+export async function getProjects(): Promise<Project[]> {
+  const response = await apiRequest<{ projects: Project[] }>("/projects");
+  return response.projects;
+}
+
+export async function getProject(projectId: string): Promise<Project> {
+  const response = await apiRequest<{ project: Project }>(`/projects/${projectId}`);
+  return response.project;
+}

--- a/frontend/src/features/projects/hooks/useCreateProjectMutation.ts
+++ b/frontend/src/features/projects/hooks/useCreateProjectMutation.ts
@@ -1,10 +1,14 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { createProject } from "../api/projectsApi";
+import { projectQueryKey } from "./useProjectQuery";
+import { projectsQueryKey } from "./useProjectsQuery";
 import { type CreateProjectFormValues } from "../schemas/createProjectSchema";
 
 
 export function useCreateProjectMutation() {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: (values: CreateProjectFormValues) =>
       createProject({
@@ -14,5 +18,9 @@ export function useCreateProjectMutation() {
         start_date: values.start_date || null,
         end_date: values.end_date || null,
       }),
+    onSuccess: (project) => {
+      queryClient.setQueryData(projectQueryKey(project.id), project);
+      queryClient.invalidateQueries({ queryKey: projectsQueryKey });
+    },
   });
 }

--- a/frontend/src/features/projects/hooks/useProjectQuery.ts
+++ b/frontend/src/features/projects/hooks/useProjectQuery.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getProject } from "../api/projectsApi";
+
+export function projectQueryKey(projectId: string) {
+  return ["projects", projectId];
+}
+
+export function useProjectQuery(projectId: string | null) {
+  return useQuery({
+    enabled: Boolean(projectId),
+    queryKey: projectId ? projectQueryKey(projectId) : ["projects", "idle"],
+    queryFn: () => getProject(projectId!),
+  });
+}

--- a/frontend/src/features/projects/hooks/useProjectsQuery.ts
+++ b/frontend/src/features/projects/hooks/useProjectsQuery.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getProjects } from "../api/projectsApi";
+
+export const projectsQueryKey = ["projects"];
+
+export function useProjectsQuery() {
+  return useQuery({
+    queryKey: projectsQueryKey,
+    queryFn: getProjects,
+  });
+}

--- a/frontend/src/features/projects/pages/ProjectsHomePage.tsx
+++ b/frontend/src/features/projects/pages/ProjectsHomePage.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
 
 import { isApiError } from "../../../api/client";
 import { Button } from "../../../components/Button";
@@ -10,13 +11,15 @@ import { StatusMessage } from "../../../components/StatusMessage";
 import { AppShellPage } from "../../auth/pages/AppShellPage";
 import { type SessionUser } from "../../auth/types";
 import { useCreateProjectMutation } from "../hooks/useCreateProjectMutation";
+import { useProjectQuery } from "../hooks/useProjectQuery";
+import { useProjectsQuery } from "../hooks/useProjectsQuery";
 import {
   createProjectSchema,
   type CreateProjectFormValues,
 } from "../schemas/createProjectSchema";
-import { type Project } from "../types";
 
 type ProjectsHomePageProps = {
+  projectId: string | null;
   user: SessionUser;
 };
 
@@ -34,9 +37,12 @@ function getDetailMessages(detail: unknown): string[] {
   return [];
 }
 
-export function ProjectsHomePage({ user }: ProjectsHomePageProps) {
+export function ProjectsHomePage({ projectId, user }: ProjectsHomePageProps) {
+  const navigate = useNavigate();
   const createProjectMutation = useCreateProjectMutation();
-  const [createdProject, setCreatedProject] = useState<Project | null>(null);
+  const projectsQuery = useProjectsQuery();
+  const projectQuery = useProjectQuery(projectId);
+  const [lastCreatedProjectId, setLastCreatedProjectId] = useState<string | null>(null);
   const {
     formState: { errors },
     handleSubmit,
@@ -55,6 +61,9 @@ export function ProjectsHomePage({ user }: ProjectsHomePageProps) {
   const projectError = isApiError(createProjectMutation.error)
     ? createProjectMutation.error
     : null;
+  const selectedProjectError = isApiError(projectQuery.error)
+    ? projectQuery.error
+    : null;
   const serverNameError = getDetailMessages(projectError?.details.name)[0];
   const serverCodeError = getDetailMessages(projectError?.details.code)[0];
   const serverStartDateError = getDetailMessages(projectError?.details.start_date)[0];
@@ -63,41 +72,147 @@ export function ProjectsHomePage({ user }: ProjectsHomePageProps) {
   const serverFormError =
     projectError?.code === "PROJECT_PERMISSION_DENIED"
       ? null
-      :
-    Object.entries(projectError?.details ?? {})
-      .flatMap(([field, detail]) =>
-        ["name", "code", "description", "start_date", "end_date"].includes(field)
-          ? []
-          : getDetailMessages(detail),
-      )[0] ??
-    (projectError &&
-    !serverNameError &&
-    !serverCodeError &&
-    !serverStartDateError &&
-    !serverEndDateError &&
-    !serverDescriptionError
-      ? projectError.message
-      : null);
+      : Object.entries(projectError?.details ?? {})
+          .flatMap(([field, detail]) =>
+            ["name", "code", "description", "start_date", "end_date"].includes(field)
+              ? []
+              : getDetailMessages(detail),
+          )[0] ??
+        (projectError &&
+        !serverNameError &&
+        !serverCodeError &&
+        !serverStartDateError &&
+        !serverEndDateError &&
+        !serverDescriptionError
+          ? projectError.message
+          : null);
 
   return (
     <AppShellPage user={user}>
-      <div className="workspace-grid">
+      <div className="workspace-grid workspace-grid--projects">
         <Panel>
+          <div className="panel-heading">
+            <h2 className="panel-heading__title">Accessible projects</h2>
+            <p className="panel-heading__body">
+              Open any project you can access from the current session. Admins see the active workspace; members only
+              see projects where their membership is still active.
+            </p>
+          </div>
+          {projectsQuery.isPending ? (
+            <StatusMessage title="Loading projects">
+              The shell is fetching the current project access list.
+            </StatusMessage>
+          ) : null}
+          {isApiError(projectsQuery.error) ? (
+            <StatusMessage tone="error" title="Project list unavailable">
+              {projectsQuery.error.message}
+            </StatusMessage>
+          ) : null}
+          {!projectsQuery.isPending &&
+          !projectsQuery.error &&
+          (projectsQuery.data?.length ?? 0) === 0 ? (
+            <StatusMessage title="No accessible projects yet">
+              Create the first project from this workspace to make a real project route available after login.
+            </StatusMessage>
+          ) : null}
+          {projectsQuery.data?.length ? (
+            <div className="project-list" role="list" aria-label="Accessible projects">
+              {projectsQuery.data.map((project) => {
+                const isSelected = project.id === projectId;
+                return (
+                  <button
+                    className={`project-list__item${isSelected ? " project-list__item--active" : ""}`}
+                    key={project.id}
+                    onClick={() => navigate(`/projects/${project.id}`)}
+                    type="button"
+                  >
+                    <span className="project-list__code">{project.code}</span>
+                    <span className="project-list__content">
+                      <strong>{project.name}</strong>
+                      <span>{project.description || "No description yet."}</span>
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          ) : null}
+        </Panel>
+
+        <Panel>
+          <div className="panel-heading">
+            <h2 className="panel-heading__title">Project details</h2>
+            <p className="panel-heading__body">
+              Opening a project now resolves a dedicated protected route instead of leaving the app on a static
+              placeholder.
+            </p>
+          </div>
+          {!projectId ? (
+            <StatusMessage title="Select a project">
+              Choose a project from the list to load its details in the workspace.
+            </StatusMessage>
+          ) : null}
+          {projectId && projectQuery.isPending ? (
+            <StatusMessage title="Loading project details">
+              The selected project route is resolving against the backend.
+            </StatusMessage>
+          ) : null}
+          {projectId && selectedProjectError?.code === "PROJECT_NOT_FOUND" ? (
+            <StatusMessage tone="warning" title="Project unavailable">
+              This project is not visible to the current account or no longer exists in the active workspace.
+            </StatusMessage>
+          ) : null}
+          {projectId &&
+          selectedProjectError &&
+          selectedProjectError.code !== "PROJECT_NOT_FOUND" ? (
+            <StatusMessage tone="error" title="Project detail unavailable">
+              {selectedProjectError.message}
+            </StatusMessage>
+          ) : null}
+          {projectQuery.data ? (
+            <div className="project-summary">
+              <div className="project-summary__code">{projectQuery.data.code}</div>
+              <h3 className="card-title">{projectQuery.data.name}</h3>
+              <p className="shell__summary project-summary__description">
+                {projectQuery.data.description || "No description was provided for this project."}
+              </p>
+              <dl className="details-list">
+                <div>
+                  <dt>Owner ID</dt>
+                  <dd>{projectQuery.data.owner_id}</dd>
+                </div>
+                <div>
+                  <dt>Task counter</dt>
+                  <dd>{projectQuery.data.task_counter}</dd>
+                </div>
+                <div>
+                  <dt>Start date</dt>
+                  <dd>{projectQuery.data.start_date || "Not set"}</dd>
+                </div>
+                <div>
+                  <dt>End date</dt>
+                  <dd>{projectQuery.data.end_date || "Not set"}</dd>
+                </div>
+              </dl>
+            </div>
+          ) : null}
+        </Panel>
+
+        <Panel className="project-create-panel">
           <div className="panel-heading">
             <h2 className="panel-heading__title">Create a project</h2>
             <p className="panel-heading__body">
-              Seed the first real product space from the authenticated shell. Project codes are normalized to uppercase
-              on submit and remain stable for later task-key generation.
+              Keep the project-creation flow in place while the shell grows into the real project workspace.
             </p>
           </div>
           <form
             className="form-stack"
             onSubmit={handleSubmit((values) => {
               createProjectMutation.reset();
-              setCreatedProject(null);
+              setLastCreatedProjectId(null);
               createProjectMutation.mutate(values, {
                 onSuccess: (project) => {
-                  setCreatedProject(project);
+                  setLastCreatedProjectId(project.id);
+                  navigate(`/projects/${project.id}`);
                 },
               });
             })}
@@ -152,50 +267,15 @@ export function ProjectsHomePage({ user }: ProjectsHomePageProps) {
                 {serverFormError}
               </StatusMessage>
             ) : null}
+            {lastCreatedProjectId && projectId === lastCreatedProjectId && !projectError ? (
+              <StatusMessage title="Project created">
+                The new project was added to the accessible list and opened directly in the workspace.
+              </StatusMessage>
+            ) : null}
             <Button disabled={createProjectMutation.isPending} type="submit">
               {createProjectMutation.isPending ? "Creating project..." : "Create project"}
             </Button>
           </form>
-        </Panel>
-
-        <Panel>
-          <div className="panel-heading">
-            <h2 className="panel-heading__title">Latest created project</h2>
-            <p className="panel-heading__body">
-              Successful project creation returns the canonical backend payload directly into the shell.
-            </p>
-          </div>
-          {createdProject ? (
-            <div className="project-summary">
-              <div className="project-summary__code">{createdProject.code}</div>
-              <h3 className="card-title">{createdProject.name}</h3>
-              <p className="shell__summary project-summary__description">
-                {createdProject.description || "No description was provided for this project."}
-              </p>
-              <dl className="details-list">
-                <div>
-                  <dt>Owner ID</dt>
-                  <dd>{createdProject.owner_id}</dd>
-                </div>
-                <div>
-                  <dt>Task counter</dt>
-                  <dd>{createdProject.task_counter}</dd>
-                </div>
-                <div>
-                  <dt>Start date</dt>
-                  <dd>{createdProject.start_date || "Not set"}</dd>
-                </div>
-                <div>
-                  <dt>End date</dt>
-                  <dd>{createdProject.end_date || "Not set"}</dd>
-                </div>
-              </dl>
-            </div>
-          ) : (
-            <StatusMessage title="No project created yet">
-              Submit the form to see the first created project payload rendered in the main application shell.
-            </StatusMessage>
-          )}
         </Panel>
       </div>
     </AppShellPage>

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -308,6 +308,10 @@ textarea {
   gap: var(--space-5);
 }
 
+.workspace-grid--projects {
+  align-items: start;
+}
+
 .status-pill {
   display: inline-flex;
   flex-direction: column;
@@ -362,6 +366,73 @@ textarea {
   gap: var(--space-4);
 }
 
+.project-list {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.project-list__item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--space-3);
+  width: 100%;
+  padding: var(--space-4);
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-strong);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color var(--motion-quick),
+    transform var(--motion-quick),
+    box-shadow var(--motion-quick);
+}
+
+.project-list__item:hover {
+  transform: translateY(-1px);
+  border-color: var(--color-border-strong);
+}
+
+.project-list__item--active {
+  border-color: var(--color-accent-primary);
+  box-shadow: 0 0 0 3px rgba(10, 127, 101, 0.12);
+}
+
+.project-list__code {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 4.5rem;
+  min-height: 2.75rem;
+  padding: 0 var(--space-3);
+  border-radius: 999px;
+  background: var(--color-bg-ink);
+  color: var(--color-text-inverse);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.project-list__content {
+  display: grid;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.project-list__content strong {
+  font-size: 1rem;
+}
+
+.project-list__content span {
+  color: var(--color-text-secondary);
+  line-height: 1.45;
+}
+
+.project-create-panel {
+  min-width: 0;
+}
+
 .project-summary__code {
   display: inline-flex;
   justify-self: start;
@@ -395,6 +466,14 @@ textarea {
 
   .workspace-grid {
     grid-template-columns: minmax(0, 1.15fr) minmax(18rem, 0.85fr);
+  }
+
+  .workspace-grid--projects {
+    grid-template-columns: minmax(18rem, 0.9fr) minmax(0, 1fr);
+  }
+
+  .project-create-panel {
+    grid-column: 1 / -1;
   }
 
   .split-fields {

--- a/issues/stories/us-011-view-project.md
+++ b/issues/stories/us-011-view-project.md
@@ -1,8 +1,21 @@
-﻿# US-011 - View Project  ## Metadata - Area: 3. Projects - GitHub labels: `user-story`, `mvp`, `area:projects` - Suggested status: `Backlog` - Suggested wave: `Wave 2` - Depends on: US-009 - Parallelization note: Start once dependencies are done; run in parallel with other stories in the same wave that do not share blocking dependencies.  ## User Story **As a** project member  
+# US-011 - View Project
+
+## Metadata
+
+- Area: 3. Projects
+- GitHub labels: `user-story`, `mvp`, `area:projects`
+- Suggested status: `Ready`
+- Suggested wave: `Wave 2`
+- Depends on: `US-009`
+- Parallelization note: This slice can start once `US-009` is in place. It should land before project edit and delete because those stories need a real read surface.
+
+## User Story
+
+**As a** project member  
 **I want** to view projects I belong to  
 **So that** I can access project work.
 
-### Acceptance Criteria
+## Acceptance Criteria
 
 **Given** I am a project member  
 **When** I open the project  
@@ -10,44 +23,55 @@
 
 **Given** I am not a project member and not an Admin  
 **When** I attempt to view the project  
-**Then** the system denies access or hides the project.  ## Implementation Breakdown **Kanban lane:** Backlog â†’ Ready â†’ Red â†’ Green â†’ Refactor â†’ Review / QA â†’ Done  
-**Definition of Done:** All listed layer tasks are complete, reviewed, tested, and traceable to the story acceptance criteria.
+**Then** the system denies access or hides the project.
 
-### Database
-- [ ] Create/maintain project schema with UUID, owner, immutable code, task counter, dates, and soft delete.
-- [ ] Add unique/index constraints for project code and owner lookups.
+## Execution Breakdown
 
-### Backend/API
-- [ ] Implement project endpoints with pagination and permission checks.
-- [ ] Enforce immutable project code on PATCH.
-- [ ] Validate project date ranges.
-- [ ] Soft-delete project, tasks, subtasks, memberships, dependencies visibility with confirmation flag.
-- [ ] Write project activity logs.
+### Backend Slice
 
-### Frontend/UI
-- [ ] Build project create/edit/detail/list UI.
-- [ ] Prevent code editing after creation in the UI.
-- [ ] Show destructive delete confirmation text exactly as specified.
+- [x] Add project read queries under the owning `projects` module for:
+  - active projects visible to the authenticated user
+  - a single active project by id when the authenticated user has access
+- [x] Implement `GET /api/projects` to return the current user's visible projects.
+- [x] Implement `GET /api/projects/{project_id}` to return project details for an accessible active project.
+- [x] Treat access as:
+  - Admin can view any active project
+  - active project members can view that project
+  - non-members and removed members cannot view the project
+- [x] Hide inaccessible or soft-deleted projects from normal reads.
 
-### TDD â€” Red: Write Failing Tests First
-- [ ] Map each Given/When/Then acceptance criterion to automated tests.
-- [ ] Add happy-path tests before implementation.
-- [ ] Add validation, permission, and edge-case tests before implementation.
-- [ ] Run the tests and confirm they fail for the expected reason.
-- [ ] Unit test immutable code, date validation, and soft-delete behavior.
-- [ ] Integration test project CRUD and deleted-project exclusion from normal views.
+### Frontend Slice
 
-### TDD â€” Green: Implement Minimum Passing Code
-- [ ] Implement only the smallest database/backend/frontend change needed to pass the failing tests.
-- [ ] Run the story-level test set and confirm all new tests pass.
-- [ ] Confirm existing regression tests still pass.
+- [x] Replace the create-only shell workspace with a project-access workspace.
+- [x] Show a visible list of accessible projects after login.
+- [x] Allow opening a project from the list into a dedicated project detail route.
+- [x] Keep the create-project form in the workspace so `US-009` stays usable.
+- [x] Surface empty, loading, and unavailable states for the new read flow.
 
-### TDD â€” Refactor: Improve Safely
-- [ ] Refactor duplicated logic into services, validators, hooks, or shared components.
-- [ ] Confirm permissions, structured errors, soft-delete behavior, and edge cases remain covered.
-- [ ] Re-run unit, integration, and relevant frontend tests after refactoring.
+### Test Slice
 
-### Review / QA Checklist
-- [ ] Acceptance criteria from the user story are verified manually or by automated tests.
-- [ ] Structured API errors, permissions, and edge cases are validated where applicable.
-- [ ] Documentation or developer notes are updated if behavior is non-obvious.
+- [x] Add backend integration coverage for listing only accessible projects for a normal member.
+- [x] Add backend integration coverage for Admin visibility across projects.
+- [x] Add backend integration coverage for successful project detail reads by an active member.
+- [x] Add backend integration coverage showing non-members and removed members cannot read a project.
+- [x] Add frontend integration coverage for loading the accessible project list after login.
+- [x] Add frontend integration coverage for opening a project detail route from the list.
+- [x] Add frontend integration coverage for an unavailable project detail route.
+
+## Dependencies And Notes
+
+- This slice intentionally stops at project read access. It does not implement:
+  - project edit mutations
+  - project code immutability enforcement on update
+  - project deletion
+  - project member management beyond honoring the existing membership rows
+- `US-010` should build on the update path introduced by `US-012`. Until a project update endpoint exists, immutability remains a project rule in the spec and model contract, but there is no meaningful PATCH surface to reject yet.
+- The frontend outcome for this story must be visible after login. A backend-only read endpoint is not sufficient for this slice.
+
+## Definition Of Done
+
+- Authenticated users can load a list of projects they are allowed to access.
+- Admins can see active projects even when they are not members.
+- Active project members can open a project detail route and view project details.
+- Non-members and removed members cannot access project details through normal reads.
+- The authenticated shell visibly changes from create-only to project-access navigation with working loading, empty, and unavailable states.

--- a/issues/stories/us-058-rate-limit-authentication-endpoints.md
+++ b/issues/stories/us-058-rate-limit-authentication-endpoints.md
@@ -1,8 +1,21 @@
-﻿# US-058 - Rate-Limit Authentication Endpoints  ## Metadata - Area: 17. Authorization and Security - GitHub labels: `user-story`, `mvp`, `area:security` - Suggested status: `Backlog` - Suggested wave: `Wave 1` - Depends on: US-001 - Parallelization note: Start once dependencies are done; run in parallel with other stories in the same wave that do not share blocking dependencies.  ## User Story **As a** system  
+# US-058 - Rate-Limit Authentication Endpoints
+
+## Metadata
+
+- Area: 17. Authorization and Security
+- GitHub labels: `user-story`, `mvp`, `area:security`
+- Suggested status: `Ready`
+- Suggested wave: `Wave 1`
+- Depends on: `US-001`
+- Parallelization note: This slice can build directly on the auth foundation and the CSRF hardening work from `US-057`.
+
+## User Story
+
+**As a** system  
 **I want** authentication endpoints to be rate-limited  
 **So that** brute-force attempts are reduced.
 
-### Acceptance Criteria
+## Acceptance Criteria
 
 **Given** repeated failed login attempts occur from the same IP or email  
 **When** the limit is exceeded  
@@ -10,46 +23,43 @@
 
 **Given** an authentication failure occurs  
 **When** the error is returned  
-**Then** the message does not reveal whether the email exists or account is inactive.  ## Implementation Breakdown **Kanban lane:** Backlog â†’ Ready â†’ Red â†’ Green â†’ Refactor â†’ Review / QA â†’ Done  
-**Definition of Done:** All listed layer tasks are complete, reviewed, tested, and traceable to the story acceptance criteria.
+**Then** the message does not reveal whether the email exists or account is inactive.
 
-### Database
-- [ ] Confirm user fields support auth state: `is_active`, `deleted_at`, `must_reset_password`, `last_login_at`.
-- [ ] Add indexes/constraints required for email uniqueness and active-user lookup.
+## Execution Breakdown
 
-### Backend/API
-- [ ] Implement/validate session endpoint behavior and generic auth errors.
-- [ ] Enforce active, non-deleted user checks before creating sessions.
-- [ ] Add service-level handling for `must_reset_password` and allowed endpoints.
-- [ ] Emit application logs for security-relevant auth events.
+### Backend Slice
 
-### Frontend/UI
-- [ ] Build guarded route behavior for authenticated, unauthenticated, and reset-required users.
-- [ ] Display validation, generic credential, expired-session, and rate-limit states.
-- [ ] Attach CSRF tokens and credentials on unsafe requests.
+- [x] Add cache-backed failure tracking for authentication endpoints under the `users` module.
+- [x] Enforce failed-login throttling by both client IP and normalized email.
+- [x] Reuse the existing generic `INVALID_CREDENTIALS` login failure for wrong password, inactive user, and missing user.
+- [x] Return a structured `RATE_LIMITED` error with HTTP `429` when the threshold is exceeded.
+- [x] Apply the same rate-limit pattern to the implemented forced-reset endpoint so the current auth endpoint surface is covered.
+- [x] Clear the relevant failure counters after a successful login.
 
-### TDD â€” Red: Write Failing Tests First
-- [ ] Map each Given/When/Then acceptance criterion to automated tests.
-- [ ] Add happy-path tests before implementation.
-- [ ] Add validation, permission, and edge-case tests before implementation.
-- [ ] Run the tests and confirm they fail for the expected reason.
-- [ ] Unit test valid/invalid credentials, inactive users, deleted users, and reset-required users.
-- [ ] Integration test full browser/API auth flow and session expiry behavior.
+### Frontend Slice
 
-### DevOps/Config
-- [ ] Configure secure cookie settings and rate-limit middleware for production/staging.
+- [x] Keep the shared client and login flow intact.
+- [x] Add explicit login-form handling for the `RATE_LIMITED` backend error state.
+- [x] Surface a visible rate-limit message without exposing account existence details.
 
-### TDD â€” Green: Implement Minimum Passing Code
-- [ ] Implement only the smallest database/backend/frontend change needed to pass the failing tests.
-- [ ] Run the story-level test set and confirm all new tests pass.
-- [ ] Confirm existing regression tests still pass.
+### Test Slice
 
-### TDD â€” Refactor: Improve Safely
-- [ ] Refactor duplicated logic into services, validators, hooks, or shared components.
-- [ ] Confirm permissions, structured errors, soft-delete behavior, and edge cases remain covered.
-- [ ] Re-run unit, integration, and relevant frontend tests after refactoring.
+- [x] Add backend integration coverage showing repeated failed logins from the same email are rate-limited.
+- [x] Add backend integration coverage showing repeated failed logins from the same IP are rate-limited.
+- [x] Add backend integration coverage proving a successful login clears the accumulated login failure counters.
+- [x] Add backend integration coverage showing forced-reset failures are rate-limited on the implemented endpoint surface.
+- [x] Keep or add frontend integration coverage showing the login form renders the rate-limit message.
 
-### Review / QA Checklist
-- [ ] Acceptance criteria from the user story are verified manually or by automated tests.
-- [ ] Structured API errors, permissions, and edge cases are validated where applicable.
-- [ ] Documentation or developer notes are updated if behavior is non-obvious.
+## Dependencies And Notes
+
+- This slice should use the Django cache backend already available in the project instead of introducing external infrastructure-specific middleware.
+- This slice should not reveal whether an email exists, whether the account is inactive, or which credential was wrong.
+- This slice does not need to implement `/auth/change-password`, which is not yet part of the current repo surface.
+
+## Definition Of Done
+
+- Repeated failed login attempts are rate-limited by both IP and email.
+- Successful login clears the relevant login failure counters.
+- Implemented authentication endpoints return a structured `RATE_LIMITED` response with HTTP `429` when blocked.
+- Generic invalid-credential responses remain generic and non-revealing.
+- The frontend login flow shows a clear rate-limit message when the backend returns `RATE_LIMITED`.

--- a/issues/stories/us-065-no-public-registration.md
+++ b/issues/stories/us-065-no-public-registration.md
@@ -1,48 +1,51 @@
-﻿# US-065 - No Public Registration  ## Metadata - Area: 21. MVP Boundary Stories - GitHub labels: `user-story`, `mvp`, `area:mvp-boundary` - Suggested status: `Backlog` - Suggested wave: `Wave 1` - Depends on: US-001 - Parallelization note: Start once dependencies are done; run in parallel with other stories in the same wave that do not share blocking dependencies.  ## User Story **As a** system owner  
+# US-065 - No Public Registration
+
+## Metadata
+
+- Area: 21. MVP Boundary Stories
+- GitHub labels: `user-story`, `mvp`, `area:mvp-boundary`
+- Suggested status: `Ready`
+- Suggested wave: `Wave 1`
+- Depends on: `US-001`
+- Parallelization note: This is a small boundary-enforcement slice on top of the auth shell.
+
+## User Story
+
+**As a** system owner  
 **I want** user creation limited to Admins  
 **So that** the internal app remains controlled.
 
-### Acceptance Criteria
+## Acceptance Criteria
 
 **Given** an unauthenticated person visits the app  
 **When** they look for sign-up  
-**Then** no public registration flow is available.  ## Implementation Breakdown **Kanban lane:** Backlog â†’ Ready â†’ Red â†’ Green â†’ Refactor â†’ Review / QA â†’ Done  
-**Definition of Done:** All listed layer tasks are complete, reviewed, tested, and traceable to the story acceptance criteria.
+**Then** no public registration flow is available.
 
-### Database
-- [ ] Confirm user fields support auth state: `is_active`, `deleted_at`, `must_reset_password`, `last_login_at`.
-- [ ] Add indexes/constraints required for email uniqueness and active-user lookup.
+## Execution Breakdown
 
-### Backend/API
-- [ ] Implement/validate session endpoint behavior and generic auth errors.
-- [ ] Enforce active, non-deleted user checks before creating sessions.
-- [ ] Add service-level handling for `must_reset_password` and allowed endpoints.
-- [ ] Emit application logs for security-relevant auth events.
+### Backend Slice
 
-### Frontend/UI
-- [ ] Build guarded route behavior for authenticated, unauthenticated, and reset-required users.
-- [ ] Display validation, generic credential, expired-session, and rate-limit states.
-- [ ] Attach CSRF tokens and credentials on unsafe requests.
+- [x] Keep user creation limited to the existing admin-only `/api/admin/users` contract.
+- [x] Add explicit backend coverage proving there is no public `/api/register` endpoint.
 
-### TDD â€” Red: Write Failing Tests First
-- [ ] Map each Given/When/Then acceptance criterion to automated tests.
-- [ ] Add happy-path tests before implementation.
-- [ ] Add validation, permission, and edge-case tests before implementation.
-- [ ] Run the tests and confirm they fail for the expected reason.
-- [ ] Unit test valid/invalid credentials, inactive users, deleted users, and reset-required users.
-- [ ] Integration test full browser/API auth flow and session expiry behavior.
+### Frontend Slice
 
-### TDD â€” Green: Implement Minimum Passing Code
-- [ ] Implement only the smallest database/backend/frontend change needed to pass the failing tests.
-- [ ] Run the story-level test set and confirm all new tests pass.
-- [ ] Confirm existing regression tests still pass.
+- [x] Keep the login page free of sign-up or create-account affordances.
+- [x] Route unknown public registration-style paths back into the existing auth flow instead of exposing a registration screen.
 
-### TDD â€” Refactor: Improve Safely
-- [ ] Refactor duplicated logic into services, validators, hooks, or shared components.
-- [ ] Confirm permissions, structured errors, soft-delete behavior, and edge cases remain covered.
-- [ ] Re-run unit, integration, and relevant frontend tests after refactoring.
+### Test Slice
 
-### Review / QA Checklist
-- [ ] Acceptance criteria from the user story are verified manually or by automated tests.
-- [ ] Structured API errors, permissions, and edge cases are validated where applicable.
-- [ ] Documentation or developer notes are updated if behavior is non-obvious.
+- [x] Add backend coverage proving `/api/register` is unavailable.
+- [x] Add frontend coverage proving unauthenticated `/register` attempts land back on the login flow.
+- [x] Add frontend coverage proving the login page does not expose sign-up UI text or actions.
+
+## Dependencies And Notes
+
+- This slice should not add a disabled registration form or placeholder sign-up page.
+- This slice should not change the admin-only create-user flow from `US-005`.
+
+## Definition Of Done
+
+- No public registration endpoint exists.
+- No public registration route or sign-up affordance exists in the frontend.
+- Unauthenticated attempts to reach a registration-style route return to the existing login flow.

--- a/skills/context/handoffs/2026-05-01-current-repo-state.md
+++ b/skills/context/handoffs/2026-05-01-current-repo-state.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-- The auth, admin-user, and first project-creation implementation stack is now landed locally through `US-009`.
+- The auth, admin-user, and first project read stack is now landed locally through `US-011`.
 - Current stacked branch and PR chain:
   - `us-001-auth-foundation` -> PR `#79`
   - `us-002-forced-first-login-password-reset` -> PR `#80`
@@ -12,40 +12,38 @@
   - `us-006-update-user` -> PR `#84`
   - `us-007-reset-user-password` -> PR `#85`
   - `us-008-deactivate-user` -> PR `#86`
-  - `us-009-create-project` -> PR pending
-- Current working branch is `us-009-create-project`.
-- GitHub issue states in this stack are `:owner-review` for `#6` through `#13`, with `#14` in implementation.
-- The only known unrelated local changes are:
+  - `us-009-create-project` -> PR `#87`
+  - `us-011-view-project` -> PR pending
+- Current working branch is `us-011-view-project`.
+- GitHub issue states in this stack are `:owner-review` for `#6` through `#14`, with `US-011` in implementation.
+- Known unrelated local changes still present and intentionally untouched:
   - modified `.gitignore`
+  - modified `AGENTS.md`
+  - modified `issues/sync-policy.md`
+  - untracked migration rename files under `backend/apps/memberships/migrations/` and `backend/apps/projects/migrations/`
 
 ## Next Recommended Step
 
-- Start `US-010 Immutable Project Code` or `US-011 View Project` from the top of the current stacked branch chain after `US-009` is pushed and opened for review.
-- Reuse the new project-create conventions:
-  - `POST /api/projects` as the first project-domain API
-  - creator becomes `owner` and receives an active `PROJECT_MANAGER` membership
-  - project creation permission is Admin or existing active `PROJECT_MANAGER` membership
-  - the authenticated shell now lands in a visible project workspace instead of an auth-only placeholder
+- Start `US-012 Edit Project` from the top of the current stacked branch chain now that a real project detail route exists.
+- `US-010 Immutable Project Code` can be delivered with or immediately before the update-path work because there is now a meaningful read surface and route contract for project details.
+- Reuse the current project conventions:
+  - `POST /api/projects` for create
+  - `GET /api/projects` for the authenticated visible-project list
+  - `GET /api/projects/{project_id}` for visible-project detail reads
+  - Admin sees all active projects; members see only active memberships
 
 ## Risks Or Open Questions
 
 - PRs are intentionally stacked. Changes to an earlier base PR can require rechecking downstream branches before continuing.
 - The admin user-management surface is still backend-only. Avoid inventing frontend admin routes until a story explicitly owns that slice.
-- The project frontend surface now exists at the protected-shell index route. Future project stories should build on that route instead of replacing it with another placeholder.
+- The project frontend surface now spans the protected-shell index route and `/projects/:projectId`. Future project stories should extend those routes instead of replacing them with another placeholder.
 - `US-008` revokes live sessions on deactivation. Do not undo that behavior by moving deactivation back into a passive field update.
-- The “Project Manager can create projects” wording remains ambiguous because memberships are project-scoped. The working rule is documented in `issues/review-findings.md` and the `US-009` handoff.
-- Context notes can drift if agents create rollup notes that overlap with existing per-story handoffs. Prefer updating this file for stack status and using story-specific notes only for story-specific implementation details.
+- The "Project Manager can create projects" wording remains ambiguous because memberships are project-scoped. The working rule is documented in `issues/review-findings.md` and the `US-009` handoff.
+- `US-010` is best treated as an update-path invariant rather than a standalone pre-read story, even though the planning order lists it before `US-011`.
 
 ## Relevant Files
 
-- `AGENTS.md`
-- `issues/stories/us-005-create-user.md`
-- `issues/stories/us-006-update-user.md`
-- `issues/stories/us-007-reset-user-password.md`
-- `issues/stories/us-008-deactivate-user.md`
 - `issues/stories/us-009-create-project.md`
-- `skills/context/handoffs/2026-05-01-us-005-create-user.md`
-- `skills/context/handoffs/2026-05-01-us-006-update-user.md`
-- `skills/context/handoffs/2026-05-01-us-007-reset-user-password.md`
-- `skills/context/handoffs/2026-05-01-us-008-deactivate-user.md`
+- `issues/stories/us-011-view-project.md`
 - `skills/context/handoffs/2026-05-02-us-009-create-project.md`
+- `skills/context/handoffs/2026-05-02-us-011-view-project.md`

--- a/skills/context/handoffs/2026-05-02-us-011-view-project.md
+++ b/skills/context/handoffs/2026-05-02-us-011-view-project.md
@@ -1,0 +1,47 @@
+# US-011 - View Project
+
+## What Landed
+
+- Added project read access on the backend:
+  - `GET /api/projects` returns the active projects visible to the authenticated user.
+  - `GET /api/projects/{project_id}` returns a single active visible project.
+- Visibility rule for this slice:
+  - Admin can view any active project.
+  - Active project members can view their project.
+  - Non-members and removed members receive `PROJECT_NOT_FOUND` on detail reads.
+- Added `backend/apps/projects/selectors.py` so project read filtering stays in the owning module instead of leaking membership predicates into views.
+
+## Frontend Outcome
+
+- The protected shell now shows an accessible-project list instead of acting like a create-only placeholder.
+- Added a dedicated protected project route at `/projects/:projectId`.
+- Opening a project loads the backend detail payload into the workspace.
+- The create-project form remains in the workspace and navigates into the newly created project on success.
+- Added explicit loading, empty, and unavailable states for project reads.
+
+## Tests
+
+- Backend: `tests/integration/test_projects_api.py`
+  - member list filtering
+  - admin visibility
+  - allowed detail read
+  - non-member blocked detail read
+  - removed-member blocked detail read
+- Frontend:
+  - `src/features/projects/ProjectsFlow.test.tsx`
+  - `src/features/auth/AuthFlow.test.tsx`
+
+## Validation Snapshot
+
+- Backend: `.\.venv\Scripts\python.exe -m pytest tests\integration\test_projects_api.py` -> `12 passed`
+- Frontend: `npm run test:run -- src/features/projects/ProjectsFlow.test.tsx src/features/auth/AuthFlow.test.tsx` -> `20 passed`
+
+## Follow-On Notes
+
+- `US-012 Edit Project` should build on the new detail route and read contract.
+- `US-010 Immutable Project Code` now has a meaningful implementation surface once the update path exists.
+- Keep the unrelated dirty files out of feature commits:
+  - `.gitignore`
+  - `AGENTS.md`
+  - `issues/sync-policy.md`
+  - the untracked migration rename files under `backend/apps/memberships/migrations/` and `backend/apps/projects/migrations/`

--- a/skills/context/handoffs/2026-05-02-us-058-rate-limit-authentication-endpoints.md
+++ b/skills/context/handoffs/2026-05-02-us-058-rate-limit-authentication-endpoints.md
@@ -1,0 +1,24 @@
+# US-058 - Rate-Limit Authentication Endpoints
+
+## What Changed
+
+- Added cache-backed authentication failure counters in the `users` domain service layer.
+- Repeated failed login attempts are now rate-limited by both client IP and normalized email.
+- Repeated failed forced-reset attempts are also rate-limited on the implemented endpoint surface.
+- The login form now renders the backend `RATE_LIMITED` error state explicitly.
+
+## Implementation Notes
+
+- The current implementation uses the Django cache backend with configurable settings:
+  - `AUTH_RATE_LIMIT_MAX_ATTEMPTS`
+  - `AUTH_RATE_LIMIT_WINDOW_SECONDS`
+- Structured `429` responses use:
+  - error code `RATE_LIMITED`
+  - `details.retry_after`
+  - `Retry-After` response header
+- Successful login clears the accumulated rate-limit counters for the matching IP and normalized email.
+
+## Validation
+
+- Backend: `py -3.12 -m pytest tests/integration/test_auth_api.py tests/integration/test_projects_api.py` with `PYTHONPATH=D:\GitHub\project-management-system\backend\.venv\Lib\site-packages` -> `60 passed`
+- Frontend: `npm run test:run -- src/features/auth/AuthFlow.test.tsx src/features/projects/ProjectsFlow.test.tsx` -> `18 passed`

--- a/skills/context/handoffs/2026-05-02-us-065-no-public-registration.md
+++ b/skills/context/handoffs/2026-05-02-us-065-no-public-registration.md
@@ -1,0 +1,13 @@
+# US-065 - No Public Registration
+
+## What Changed
+
+- Made the MVP boundary explicit instead of leaving it implicit in the current auth shell.
+- Added backend coverage proving there is no public `/api/register` endpoint.
+- Added frontend route fallback behavior so unauthenticated `/register` attempts return to the login flow.
+- Added frontend coverage proving the login screen exposes no sign-up or create-account affordance.
+
+## Validation
+
+- Backend: `py -3.12 -m pytest tests/integration/test_auth_api.py tests/integration/test_projects_api.py` with `PYTHONPATH=D:\GitHub\project-management-system\backend\.venv\Lib\site-packages` -> `61 passed`
+- Frontend: `npm run test:run -- src/features/auth/AuthFlow.test.tsx src/features/projects/ProjectsFlow.test.tsx` -> `19 passed`


### PR DESCRIPTION
## Summary
- add backend project list/detail reads with membership or admin visibility
- turn the protected shell into a real project access workspace with `/projects/:projectId`
- keep project creation in place while adding project list/detail coverage and handoff notes

## Validation
- `D:\GitHub\project-management-system\backend\.venv\Scripts\python.exe -m pytest tests\integration\test_projects_api.py` -> `12 passed`
- `npm run test:run -- src/features/projects/ProjectsFlow.test.tsx src/features/auth/AuthFlow.test.tsx` -> `20 passed`
