### PR TITLE
Implement US-012 edit project and US-010 immutable project code

### DIFF
--- a/backend/apps/projects/api/serializers.py
+++ b/backend/apps/projects/api/serializers.py
@@ -1,10 +1,20 @@
 from rest_framework import serializers
 
+from apps.memberships.models import ProjectMembershipRole
+
 
 class CreateProjectSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=255)
     code = serializers.CharField(max_length=32)
     description = serializers.CharField(required=False, allow_blank=True)
+    start_date = serializers.DateField(required=False, allow_null=True)
+    end_date = serializers.DateField(required=False, allow_null=True)
+
+
+class UpdateProjectSerializer(serializers.Serializer):
+    name = serializers.CharField(max_length=255, required=False)
+    code = serializers.CharField(max_length=32, required=False)
+    description = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     start_date = serializers.DateField(required=False, allow_null=True)
     end_date = serializers.DateField(required=False, allow_null=True)
 
@@ -18,3 +28,15 @@ class ProjectSerializer(serializers.Serializer):
     task_counter = serializers.IntegerField()
     start_date = serializers.DateField(allow_null=True)
     end_date = serializers.DateField(allow_null=True)
+
+
+class ProjectDetailSerializer(ProjectSerializer):
+    can_edit = serializers.SerializerMethodField()
+
+    def get_can_edit(self, obj):
+        user = self.context["user"]
+        return user.is_admin or obj.memberships.filter(
+            user=user,
+            role=ProjectMembershipRole.PROJECT_MANAGER,
+            deleted_at__isnull=True,
+        ).exists()

--- a/backend/apps/projects/api/views.py
+++ b/backend/apps/projects/api/views.py
@@ -11,10 +11,18 @@ from apps.projects.domain.services import (
     InvalidProjectDateRangeError,
     list_projects_for_actor,
     ProjectNotFoundError,
+    ProjectCodeImmutableError,
     ProjectCreatePermissionDeniedError,
+    ProjectEditPermissionDeniedError,
+    update_project,
 )
 
-from .serializers import CreateProjectSerializer, ProjectSerializer
+from .serializers import (
+    CreateProjectSerializer,
+    ProjectDetailSerializer,
+    ProjectSerializer,
+    UpdateProjectSerializer,
+)
 
 
 def error_response(*, code: str, message: str, details: dict, status_code: int) -> Response:
@@ -99,6 +107,56 @@ class ProjectDetailView(APIView):
             )
 
         return Response(
-            {"project": ProjectSerializer(project).data},
+            {"project": ProjectDetailSerializer(project, context={"user": request.user}).data},
+            status=status.HTTP_200_OK,
+        )
+
+    def patch(self, request, project_id):
+        serializer = UpdateProjectSerializer(data=request.data, partial=True)
+        if not serializer.is_valid():
+            return error_response(
+                code="VALIDATION_ERROR",
+                message="Invalid input",
+                details=serializer.errors,
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            project = update_project(
+                actor=request.user,
+                project_id=project_id,
+                updates=serializer.validated_data,
+            )
+        except ProjectNotFoundError:
+            return error_response(
+                code="PROJECT_NOT_FOUND",
+                message="Project not found.",
+                details={},
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
+        except ProjectEditPermissionDeniedError:
+            return error_response(
+                code="PROJECT_PERMISSION_DENIED",
+                message="You do not have permission to edit this project.",
+                details={},
+                status_code=status.HTTP_403_FORBIDDEN,
+            )
+        except ProjectCodeImmutableError:
+            return error_response(
+                code="PROJECT_CODE_IMMUTABLE",
+                message="Project code cannot be changed.",
+                details={"code": ["Project code cannot be changed."]},
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+        except InvalidProjectDateRangeError as exc:
+            return error_response(
+                code="VALIDATION_ERROR",
+                message="Invalid input",
+                details=exc.details,
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+
+        return Response(
+            {"project": ProjectDetailSerializer(project, context={"user": request.user}).data},
             status=status.HTTP_200_OK,
         )

--- a/backend/apps/projects/domain/policies.py
+++ b/backend/apps/projects/domain/policies.py
@@ -9,3 +9,14 @@ def can_create_project(*, user) -> bool:
         user=user,
         role=ProjectMembershipRole.PROJECT_MANAGER,
     ).exists()
+
+
+def can_edit_project(*, user, project) -> bool:
+    if user.is_admin:
+        return True
+
+    return ProjectMembership.objects.filter(
+        project=project,
+        user=user,
+        role=ProjectMembershipRole.PROJECT_MANAGER,
+    ).exists()

--- a/backend/apps/projects/domain/services.py
+++ b/backend/apps/projects/domain/services.py
@@ -4,7 +4,7 @@ from apps.memberships.models import ProjectMembership, ProjectMembershipRole
 from apps.projects.models import Project
 from apps.projects.selectors import visible_projects_for_user
 
-from .policies import can_create_project
+from .policies import can_create_project, can_edit_project
 
 
 class ProjectCreatePermissionDeniedError(Exception):
@@ -25,6 +25,14 @@ class ProjectNotFoundError(Exception):
     pass
 
 
+class ProjectEditPermissionDeniedError(Exception):
+    pass
+
+
+class ProjectCodeImmutableError(Exception):
+    pass
+
+
 def list_projects_for_actor(*, actor):
     return list(visible_projects_for_user(user=actor))
 
@@ -33,6 +41,51 @@ def get_project_for_actor(*, actor, project_id):
     project = visible_projects_for_user(user=actor).filter(id=project_id).first()
     if project is None:
         raise ProjectNotFoundError
+
+    return project
+
+
+@transaction.atomic
+def update_project(
+    *,
+    actor,
+    project_id,
+    updates: dict,
+):
+    project = get_project_for_actor(actor=actor, project_id=project_id)
+
+    if not can_edit_project(user=actor, project=project):
+        raise ProjectEditPermissionDeniedError
+
+    if "code" in updates:
+        raise ProjectCodeImmutableError
+
+    next_start_date = updates.get("start_date", project.start_date)
+    next_end_date = updates.get("end_date", project.end_date)
+
+    if next_start_date and next_end_date and next_end_date < next_start_date:
+        raise InvalidProjectDateRangeError(
+            {"end_date": ["End date cannot be earlier than start date."]}
+        )
+
+    if "name" in updates:
+        project.name = updates["name"]
+    if "description" in updates:
+        project.description = updates["description"] or None
+    if "start_date" in updates:
+        project.start_date = updates["start_date"]
+    if "end_date" in updates:
+        project.end_date = updates["end_date"]
+
+    project.save(
+        update_fields=[
+            "name",
+            "description",
+            "start_date",
+            "end_date",
+            "updated_at",
+        ]
+    )
 
     return project
 

--- a/backend/tests/integration/test_projects_api.py
+++ b/backend/tests/integration/test_projects_api.py
@@ -383,6 +383,7 @@ def test_active_project_member_can_view_project_details():
             "task_counter": 0,
             "start_date": None,
             "end_date": None,
+            "can_edit": False,
         }
     }
 
@@ -438,3 +439,177 @@ def test_removed_member_cannot_view_project_details():
             "details": {},
         }
     }
+
+
+def test_admin_can_edit_project_details():
+    admin_user = create_user(
+        email="project-edit-admin@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    project = create_project(owner=admin_user, code="EDT", name="Editable Project")
+    client = APIClient()
+    client.force_login(admin_user)
+
+    response = client.patch(
+        f"/api/projects/{project.id}",
+        {
+            "name": "Updated Project Name",
+            "description": "Updated project description",
+            "start_date": "2026-05-03",
+            "end_date": "2026-06-03",
+        },
+        format="json",
+    )
+
+    project.refresh_from_db()
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "project": {
+            "id": str(project.id),
+            "name": "Updated Project Name",
+            "code": "EDT",
+            "description": "Updated project description",
+            "owner_id": str(admin_user.id),
+            "task_counter": 0,
+            "start_date": "2026-05-03",
+            "end_date": "2026-06-03",
+            "can_edit": True,
+        }
+    }
+    assert project.name == "Updated Project Name"
+    assert project.description == "Updated project description"
+
+
+def test_project_manager_can_edit_project_details():
+    admin_user = create_user(
+        email="project-edit-seed-admin@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    project_manager = create_user(email="project-edit-manager@example.com")
+    project = create_project(owner=admin_user, code="PMG", name="Managed Project")
+    create_membership(
+        project=project,
+        user=project_manager,
+        role=ProjectMembershipRole.PROJECT_MANAGER,
+    )
+    client = APIClient()
+    client.force_login(project_manager)
+
+    response = client.patch(
+        f"/api/projects/{project.id}",
+        {
+            "name": "Managed Project Updated",
+        },
+        format="json",
+    )
+
+    project.refresh_from_db()
+
+    assert response.status_code == 200
+    assert response.json()["project"]["name"] == "Managed Project Updated"
+    assert response.json()["project"]["can_edit"] is True
+    assert project.name == "Managed Project Updated"
+
+
+def test_team_member_cannot_edit_project_details():
+    admin_user = create_user(
+        email="project-edit-member-admin@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    team_member = create_user(email="project-edit-member@example.com")
+    project = create_project(owner=admin_user, code="TMR", name="Team Member Readonly")
+    create_membership(
+        project=project,
+        user=team_member,
+        role=ProjectMembershipRole.TEAM_MEMBER,
+    )
+    client = APIClient()
+    client.force_login(team_member)
+
+    response = client.patch(
+        f"/api/projects/{project.id}",
+        {
+            "name": "Should Not Save",
+        },
+        format="json",
+    )
+
+    project.refresh_from_db()
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "error": {
+            "code": "PROJECT_PERMISSION_DENIED",
+            "message": "You do not have permission to edit this project.",
+            "details": {},
+        }
+    }
+    assert project.name == "Team Member Readonly"
+
+
+def test_project_update_rejects_invalid_date_range():
+    admin_user = create_user(
+        email="project-edit-dates-admin@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    project = create_project(owner=admin_user, code="DTR", name="Date Range Project")
+    client = APIClient()
+    client.force_login(admin_user)
+
+    response = client.patch(
+        f"/api/projects/{project.id}",
+        {
+            "start_date": "2026-06-03",
+            "end_date": "2026-05-03",
+        },
+        format="json",
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": {
+            "code": "VALIDATION_ERROR",
+            "message": "Invalid input",
+            "details": {
+                "end_date": ["End date cannot be earlier than start date."],
+            },
+        }
+    }
+
+
+def test_project_update_rejects_project_code_changes():
+    admin_user = create_user(
+        email="project-edit-code-admin@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    project = create_project(owner=admin_user, code="IMM", name="Immutable Code Project")
+    client = APIClient()
+    client.force_login(admin_user)
+
+    response = client.patch(
+        f"/api/projects/{project.id}",
+        {
+            "code": "NEW",
+        },
+        format="json",
+    )
+
+    project.refresh_from_db()
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": {
+            "code": "PROJECT_CODE_IMMUTABLE",
+            "message": "Project code cannot be changed.",
+            "details": {
+                "code": ["Project code cannot be changed."],
+            },
+        }
+    }
+    assert project.code == "IMM"

--- a/frontend/src/features/projects/ProjectsFlow.test.tsx
+++ b/frontend/src/features/projects/ProjectsFlow.test.tsx
@@ -66,6 +66,7 @@ describe("projects flow", () => {
             task_counter: 0,
             start_date: "2026-05-01",
             end_date: "2026-06-01",
+            can_edit: false,
           },
         },
       }),
@@ -146,6 +147,7 @@ describe("projects flow", () => {
             task_counter: 0,
             start_date: "2026-05-01",
             end_date: "2026-06-01",
+            can_edit: true,
           },
         },
       }),
@@ -160,6 +162,7 @@ describe("projects flow", () => {
             task_counter: 0,
             start_date: "2026-05-01",
             end_date: "2026-06-01",
+            can_edit: true,
           },
         },
       }),
@@ -190,6 +193,7 @@ describe("projects flow", () => {
             task_counter: 0,
             start_date: "2026-05-01",
             end_date: "2026-06-01",
+            can_edit: true,
           },
         },
       }),
@@ -277,5 +281,131 @@ describe("projects flow", () => {
     expect(
       await screen.findByText("A project with this code already exists."),
     ).toBeInTheDocument();
+  });
+
+  it("edits a project from the detail workspace without exposing a mutable code field", async () => {
+    const fetchMock = mockFetchSequence([
+      jsonResponse({
+        body: {
+          id: "user-1",
+          email: "jane@example.com",
+          name: "Jane Doe",
+          is_admin: true,
+          must_reset_password: false,
+        },
+      }),
+      jsonResponse({
+        body: {
+          projects: [
+            {
+              id: "project-1",
+              name: "Engineering Platform",
+              code: "ENG",
+              description: "Internal engineering work",
+              owner_id: "user-1",
+              task_counter: 0,
+              start_date: "2026-05-01",
+              end_date: "2026-06-01",
+            },
+          ],
+        },
+      }),
+      jsonResponse({
+        body: {
+          project: {
+            id: "project-1",
+            name: "Engineering Platform",
+            code: "ENG",
+            description: "Internal engineering work",
+            owner_id: "user-1",
+            task_counter: 0,
+            start_date: "2026-05-01",
+            end_date: "2026-06-01",
+            can_edit: true,
+          },
+        },
+      }),
+      jsonResponse({
+        body: {
+          project: {
+            id: "project-1",
+            name: "Engineering Platform Updated",
+            code: "ENG",
+            description: "Updated project description",
+            owner_id: "user-1",
+            task_counter: 0,
+            start_date: "2026-05-04",
+            end_date: "2026-06-10",
+            can_edit: true,
+          },
+        },
+      }),
+    ]);
+
+    const user = userEvent.setup();
+    renderApp(["/projects/project-1"], { cookie: "csrftoken=test-token; path=/" });
+
+    const editStartDateInput = (await screen.findAllByLabelText(/^start date$/i))[0]!;
+    const editEndDateInput = (await screen.findAllByLabelText(/^end date$/i))[0]!;
+    await user.clear(editStartDateInput);
+    await user.type(editStartDateInput, "2026-05-04");
+    await user.clear(editEndDateInput);
+    await user.type(editEndDateInput, "2026-06-10");
+    await user.click(screen.getAllByRole("button", { name: /save changes/i }).at(-1)!);
+
+    expect(await screen.findByText(/project updated/i)).toBeInTheDocument();
+    expect(screen.getAllByDisplayValue("ENG")[0]).toHaveAttribute("readonly");
+    expect(fetchMock.mock.calls[3]?.[0]).toBe("/api/projects/project-1");
+    expect(fetchMock.mock.calls[3]?.[1]?.method).toBe("PATCH");
+  });
+
+  it("shows a read-only edit state for project members without edit permission", async () => {
+    mockFetchSequence([
+      jsonResponse({
+        body: {
+          id: "user-2",
+          email: "member@example.com",
+          name: "Team Member",
+          is_admin: false,
+          must_reset_password: false,
+        },
+      }),
+      jsonResponse({
+        body: {
+          projects: [
+            {
+              id: "project-1",
+              name: "Engineering Platform",
+              code: "ENG",
+              description: "Internal engineering work",
+              owner_id: "owner-1",
+              task_counter: 0,
+              start_date: "2026-05-01",
+              end_date: "2026-06-01",
+            },
+          ],
+        },
+      }),
+      jsonResponse({
+        body: {
+          project: {
+            id: "project-1",
+            name: "Engineering Platform",
+            code: "ENG",
+            description: "Internal engineering work",
+            owner_id: "owner-1",
+            task_counter: 0,
+            start_date: "2026-05-01",
+            end_date: "2026-06-01",
+            can_edit: false,
+          },
+        },
+      }),
+    ]);
+
+    renderApp(["/projects/project-1"], { cookie: "csrftoken=test-token; path=/" });
+
+    expect(await screen.findByText(/read-only access/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /save changes/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/projects/api/projectsApi.ts
+++ b/frontend/src/features/projects/api/projectsApi.ts
@@ -1,5 +1,5 @@
 import { apiRequest } from "../../../api/client";
-import { type CreateProjectRequest, type Project } from "../types";
+import { type CreateProjectRequest, type Project, type ProjectDetail, type UpdateProjectRequest } from "../types";
 
 
 export async function createProject(payload: CreateProjectRequest): Promise<Project> {
@@ -16,7 +16,19 @@ export async function getProjects(): Promise<Project[]> {
   return response.projects;
 }
 
-export async function getProject(projectId: string): Promise<Project> {
-  const response = await apiRequest<{ project: Project }>(`/projects/${projectId}`);
+export async function getProject(projectId: string): Promise<ProjectDetail> {
+  const response = await apiRequest<{ project: ProjectDetail }>(`/projects/${projectId}`);
+  return response.project;
+}
+
+export async function updateProject(
+  projectId: string,
+  payload: UpdateProjectRequest,
+): Promise<ProjectDetail> {
+  const response = await apiRequest<{ project: ProjectDetail }>(`/projects/${projectId}`, {
+    body: JSON.stringify(payload),
+    method: "PATCH",
+  });
+
   return response.project;
 }

--- a/frontend/src/features/projects/hooks/useCreateProjectMutation.ts
+++ b/frontend/src/features/projects/hooks/useCreateProjectMutation.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { createProject } from "../api/projectsApi";
+import { type Project } from "../types";
 import { projectQueryKey } from "./useProjectQuery";
 import { projectsQueryKey } from "./useProjectsQuery";
 import { type CreateProjectFormValues } from "../schemas/createProjectSchema";
@@ -20,7 +21,12 @@ export function useCreateProjectMutation() {
       }),
     onSuccess: (project) => {
       queryClient.setQueryData(projectQueryKey(project.id), project);
-      queryClient.invalidateQueries({ queryKey: projectsQueryKey });
+      queryClient.setQueryData<Project[] | undefined>(projectsQueryKey, (projects) => {
+        const currentProjects = projects ?? [];
+        return currentProjects.some((currentProject) => currentProject.id === project.id)
+          ? currentProjects
+          : [...currentProjects, project];
+      });
     },
   });
 }

--- a/frontend/src/features/projects/hooks/useUpdateProjectMutation.ts
+++ b/frontend/src/features/projects/hooks/useUpdateProjectMutation.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { updateProject } from "../api/projectsApi";
+import { type Project } from "../types";
+import { projectQueryKey } from "./useProjectQuery";
+import { projectsQueryKey } from "./useProjectsQuery";
+import { type UpdateProjectFormValues } from "../schemas/updateProjectSchema";
+
+export function useUpdateProjectMutation(projectId: string | null) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (values: UpdateProjectFormValues) =>
+      updateProject(projectId!, {
+        name: values.name.trim(),
+        description: values.description?.trim() || null,
+        start_date: values.start_date || null,
+        end_date: values.end_date || null,
+      }),
+    onSuccess: (project) => {
+      queryClient.setQueryData(projectQueryKey(project.id), project);
+      queryClient.setQueryData<Project[] | undefined>(projectsQueryKey, (projects) =>
+        projects?.map((currentProject) =>
+          currentProject.id === project.id
+            ? {
+                ...currentProject,
+                name: project.name,
+                description: project.description,
+                start_date: project.start_date,
+                end_date: project.end_date,
+              }
+            : currentProject,
+        ) ?? [],
+      );
+    },
+  });
+}

--- a/frontend/src/features/projects/pages/ProjectsHomePage.tsx
+++ b/frontend/src/features/projects/pages/ProjectsHomePage.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 
@@ -13,10 +13,15 @@ import { type SessionUser } from "../../auth/types";
 import { useCreateProjectMutation } from "../hooks/useCreateProjectMutation";
 import { useProjectQuery } from "../hooks/useProjectQuery";
 import { useProjectsQuery } from "../hooks/useProjectsQuery";
+import { useUpdateProjectMutation } from "../hooks/useUpdateProjectMutation";
 import {
   createProjectSchema,
   type CreateProjectFormValues,
 } from "../schemas/createProjectSchema";
+import {
+  updateProjectSchema,
+  type UpdateProjectFormValues,
+} from "../schemas/updateProjectSchema";
 
 type ProjectsHomePageProps = {
   projectId: string | null;
@@ -42,7 +47,9 @@ export function ProjectsHomePage({ projectId, user }: ProjectsHomePageProps) {
   const createProjectMutation = useCreateProjectMutation();
   const projectsQuery = useProjectsQuery();
   const projectQuery = useProjectQuery(projectId);
+  const updateProjectMutation = useUpdateProjectMutation(projectId);
   const [lastCreatedProjectId, setLastCreatedProjectId] = useState<string | null>(null);
+  const [showEditSuccess, setShowEditSuccess] = useState(false);
   const {
     formState: { errors },
     handleSubmit,
@@ -57,12 +64,29 @@ export function ProjectsHomePage({ projectId, user }: ProjectsHomePageProps) {
     },
     resolver: zodResolver(createProjectSchema),
   });
+  const {
+    formState: { errors: editErrors },
+    handleSubmit: handleEditSubmit,
+    register: registerEdit,
+    reset: resetEditForm,
+  } = useForm<UpdateProjectFormValues>({
+    defaultValues: {
+      name: "",
+      description: "",
+      start_date: "",
+      end_date: "",
+    },
+    resolver: zodResolver(updateProjectSchema),
+  });
 
   const projectError = isApiError(createProjectMutation.error)
     ? createProjectMutation.error
     : null;
   const selectedProjectError = isApiError(projectQuery.error)
     ? projectQuery.error
+    : null;
+  const updateProjectError = isApiError(updateProjectMutation.error)
+    ? updateProjectMutation.error
     : null;
   const serverNameError = getDetailMessages(projectError?.details.name)[0];
   const serverCodeError = getDetailMessages(projectError?.details.code)[0];
@@ -86,6 +110,41 @@ export function ProjectsHomePage({ projectId, user }: ProjectsHomePageProps) {
         !serverDescriptionError
           ? projectError.message
           : null);
+  const serverEditNameError = getDetailMessages(updateProjectError?.details.name)[0];
+  const serverEditDescriptionError = getDetailMessages(updateProjectError?.details.description)[0];
+  const serverEditStartDateError = getDetailMessages(updateProjectError?.details.start_date)[0];
+  const serverEditEndDateError = getDetailMessages(updateProjectError?.details.end_date)[0];
+  const serverEditCodeError = getDetailMessages(updateProjectError?.details.code)[0];
+  const serverEditFormError =
+    updateProjectError?.code === "PROJECT_PERMISSION_DENIED"
+      ? null
+      : updateProjectError &&
+        !serverEditNameError &&
+        !serverEditDescriptionError &&
+        !serverEditStartDateError &&
+        !serverEditEndDateError &&
+        !serverEditCodeError
+      ? updateProjectError.message
+      : null;
+
+  useEffect(() => {
+    if (!projectQuery.data) {
+      resetEditForm({
+        name: "",
+        description: "",
+        start_date: "",
+        end_date: "",
+      });
+      return;
+    }
+
+    resetEditForm({
+      name: projectQuery.data.name,
+      description: projectQuery.data.description ?? "",
+      start_date: projectQuery.data.start_date ?? "",
+      end_date: projectQuery.data.end_date ?? "",
+    });
+  }, [projectQuery.data, resetEditForm]);
 
   return (
     <AppShellPage user={user}>
@@ -193,7 +252,104 @@ export function ProjectsHomePage({ projectId, user }: ProjectsHomePageProps) {
                   <dd>{projectQuery.data.end_date || "Not set"}</dd>
                 </div>
               </dl>
+              <div className="project-summary__rule">
+                Project code is locked after creation and cannot be edited.
+              </div>
             </div>
+          ) : null}
+        </Panel>
+
+        <Panel className="project-edit-panel">
+          <div className="panel-heading">
+            <h2 className="panel-heading__title">Edit project</h2>
+            <p className="panel-heading__body">
+              Update the current project details without changing the stable project code used for future task keys.
+            </p>
+          </div>
+          {!projectQuery.data ? (
+            <StatusMessage title="Project edit is unavailable">
+              Select a project detail route before editing.
+            </StatusMessage>
+          ) : null}
+          {projectQuery.data && !projectQuery.data.can_edit ? (
+            <StatusMessage tone="warning" title="Read-only access">
+              Only Admins and active Project Managers can edit this project. The current account can view details but
+              cannot change them.
+            </StatusMessage>
+          ) : null}
+          {projectQuery.data?.can_edit ? (
+            <form
+              className="form-stack"
+              onSubmit={handleEditSubmit((values) => {
+                setShowEditSuccess(false);
+                updateProjectMutation.reset();
+                updateProjectMutation.mutate(values, {
+                  onSuccess: () => {
+                    setShowEditSuccess(true);
+                  },
+                });
+              })}
+            >
+              <Field
+                error={editErrors.name?.message ?? serverEditNameError}
+                label="Project name"
+                type="text"
+                {...registerEdit("name")}
+              />
+              <Field
+                error={serverEditCodeError}
+                label="Project code"
+                readOnly
+                type="text"
+                value={projectQuery.data.code}
+              />
+              <label className="field" htmlFor="edit-description">
+                <span className="field__label">Description</span>
+                <textarea
+                  className="field__input field__input--textarea"
+                  id="edit-description"
+                  rows={4}
+                  {...registerEdit("description")}
+                />
+                {editErrors.description?.message ?? serverEditDescriptionError ? (
+                  <span className="field__error" role="alert">
+                    {editErrors.description?.message ?? serverEditDescriptionError}
+                  </span>
+                ) : null}
+              </label>
+              <div className="split-fields">
+                <Field
+                  error={editErrors.start_date?.message ?? serverEditStartDateError}
+                  label="Start date"
+                  type="date"
+                  {...registerEdit("start_date")}
+                />
+                <Field
+                  error={editErrors.end_date?.message ?? serverEditEndDateError}
+                  label="End date"
+                  type="date"
+                  {...registerEdit("end_date")}
+                />
+              </div>
+              {updateProjectError?.code === "PROJECT_PERMISSION_DENIED" ? (
+                <StatusMessage tone="error" title="Permission denied">
+                  {updateProjectError.message}
+                </StatusMessage>
+              ) : null}
+              {serverEditFormError ? (
+                <StatusMessage tone="error" title="Project update failed">
+                  {serverEditFormError}
+                </StatusMessage>
+              ) : null}
+              {showEditSuccess ? (
+                <StatusMessage title="Project updated">
+                  The current project details were saved successfully.
+                </StatusMessage>
+              ) : null}
+              <Button disabled={updateProjectMutation.isPending} type="submit">
+                {updateProjectMutation.isPending ? "Saving changes..." : "Save changes"}
+              </Button>
+            </form>
           ) : null}
         </Panel>
 

--- a/frontend/src/features/projects/schemas/updateProjectSchema.ts
+++ b/frontend/src/features/projects/schemas/updateProjectSchema.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+export const updateProjectSchema = z
+  .object({
+    name: z.string().trim().min(1, "Project name is required").max(255, "Project name is too long"),
+    description: z.string().max(5000, "Description is too long").optional(),
+    start_date: z.string().optional(),
+    end_date: z.string().optional(),
+  })
+  .superRefine((values, ctx) => {
+    if (values.start_date && values.end_date && values.end_date < values.start_date) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "End date cannot be earlier than start date.",
+        path: ["end_date"],
+      });
+    }
+  });
+
+export type UpdateProjectFormValues = z.infer<typeof updateProjectSchema>;

--- a/frontend/src/features/projects/types.ts
+++ b/frontend/src/features/projects/types.ts
@@ -9,10 +9,22 @@ export type Project = {
   end_date: string | null;
 };
 
+export type ProjectDetail = Project & {
+  can_edit: boolean;
+};
+
 export type CreateProjectRequest = {
   name: string;
   code: string;
   description?: string;
+  start_date?: string | null;
+  end_date?: string | null;
+};
+
+export type UpdateProjectRequest = {
+  name?: string;
+  code?: string;
+  description?: string | null;
   start_date?: string | null;
   end_date?: string | null;
 };

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -451,6 +451,18 @@ textarea {
   margin: 0;
 }
 
+.project-summary__rule {
+  padding: var(--space-3) var(--space-4);
+  border: 1px dashed var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-secondary);
+  background: var(--color-surface-strong);
+}
+
+.project-edit-panel {
+  min-width: 0;
+}
+
 @media (min-width: 860px) {
   .screen__content {
     grid-template-columns: minmax(0, 1.3fr) minmax(22rem, 0.9fr);
@@ -473,6 +485,10 @@ textarea {
   }
 
   .project-create-panel {
+    grid-column: 1 / -1;
+  }
+
+  .project-edit-panel {
     grid-column: 1 / -1;
   }
 

--- a/issues/stories/us-010-immutable-project-code.md
+++ b/issues/stories/us-010-immutable-project-code.md
@@ -1,49 +1,51 @@
-﻿# US-010 - Immutable Project Code  ## Metadata - Area: 3. Projects - GitHub labels: `user-story`, `mvp`, `area:projects` - Suggested status: `Backlog` - Suggested wave: `Wave 2` - Depends on: US-009 - Parallelization note: Start once dependencies are done; run in parallel with other stories in the same wave that do not share blocking dependencies.  ## User Story **As a** system  
+# US-010 - Immutable Project Code
+
+## Metadata
+
+- Area: 3. Projects
+- GitHub labels: `user-story`, `mvp`, `area:projects`
+- Suggested status: `Ready`
+- Suggested wave: `Wave 2`
+- Depends on: `US-009`
+- Parallelization note: Deliver this invariant on the same branch as `US-012`, because the PATCH surface is the first meaningful place to enforce it.
+
+## User Story
+
+**As a** system  
 **I want** project codes to remain immutable  
 **So that** task keys remain stable forever.
 
-### Acceptance Criteria
+## Acceptance Criteria
 
 **Given** a project already exists  
 **When** a user attempts to update the project code  
-**Then** the system rejects the request with `PROJECT_CODE_IMMUTABLE`.  ## Implementation Breakdown **Kanban lane:** Backlog â†’ Ready â†’ Red â†’ Green â†’ Refactor â†’ Review / QA â†’ Done  
-**Definition of Done:** All listed layer tasks are complete, reviewed, tested, and traceable to the story acceptance criteria.
+**Then** the system rejects the request with `PROJECT_CODE_IMMUTABLE`.
 
-### Database
-- [ ] Create/maintain project schema with UUID, owner, immutable code, task counter, dates, and soft delete.
-- [ ] Add unique/index constraints for project code and owner lookups.
+## Execution Breakdown
 
-### Backend/API
-- [ ] Implement project endpoints with pagination and permission checks.
-- [ ] Enforce immutable project code on PATCH.
-- [ ] Validate project date ranges.
-- [ ] Soft-delete project, tasks, subtasks, memberships, dependencies visibility with confirmation flag.
-- [ ] Write project activity logs.
+### Backend Slice
 
-### Frontend/UI
-- [ ] Build project create/edit/detail/list UI.
-- [ ] Prevent code editing after creation in the UI.
-- [ ] Show destructive delete confirmation text exactly as specified.
+- [x] Reject any `PATCH /api/projects/{project_id}` request that includes `code`.
+- [x] Return a structured `PROJECT_CODE_IMMUTABLE` error without mutating the project.
+- [x] Keep other editable fields on the same PATCH route updateable when `code` is absent.
 
-### TDD â€” Red: Write Failing Tests First
-- [ ] Map each Given/When/Then acceptance criterion to automated tests.
-- [ ] Add happy-path tests before implementation.
-- [ ] Add validation, permission, and edge-case tests before implementation.
-- [ ] Run the tests and confirm they fail for the expected reason.
-- [ ] Unit test immutable code, date validation, and soft-delete behavior.
-- [ ] Integration test project CRUD and deleted-project exclusion from normal views.
+### Frontend Slice
 
-### TDD â€” Green: Implement Minimum Passing Code
-- [ ] Implement only the smallest database/backend/frontend change needed to pass the failing tests.
-- [ ] Run the story-level test set and confirm all new tests pass.
-- [ ] Confirm existing regression tests still pass.
+- [x] Do not expose editable project code in the project edit UI.
+- [x] Keep the existing project code visible as a stable identifier in the detail workspace.
 
-### TDD â€” Refactor: Improve Safely
-- [ ] Refactor duplicated logic into services, validators, hooks, or shared components.
-- [ ] Confirm permissions, structured errors, soft-delete behavior, and edge cases remain covered.
-- [ ] Re-run unit, integration, and relevant frontend tests after refactoring.
+### Test Slice
 
-### Review / QA Checklist
-- [ ] Acceptance criteria from the user story are verified manually or by automated tests.
-- [ ] Structured API errors, permissions, and edge cases are validated where applicable.
-- [ ] Documentation or developer notes are updated if behavior is non-obvious.
+- [x] Add backend integration coverage for `code` rejection on the project PATCH route.
+- [x] Add frontend coverage showing the edit UI does not offer a mutable project-code field.
+
+## Dependencies And Notes
+
+- This story is satisfied as part of the `US-012` project update slice.
+- The invariant matters before task-key generation work, but it does not need a separate route or UI beyond the edit flow.
+
+## Definition Of Done
+
+- Project PATCH requests containing `code` return `PROJECT_CODE_IMMUTABLE`.
+- The edit UI does not allow project code changes.
+- Successful non-code edits still work through the same update route.

--- a/issues/stories/us-012-edit-project.md
+++ b/issues/stories/us-012-edit-project.md
@@ -1,8 +1,21 @@
-﻿# US-012 - Edit Project  ## Metadata - Area: 3. Projects - GitHub labels: `user-story`, `mvp`, `area:projects` - Suggested status: `Backlog` - Suggested wave: `Wave 2` - Depends on: US-009, US-011 - Parallelization note: Start once dependencies are done; run in parallel with other stories in the same wave that do not share blocking dependencies.  ## User Story **As an** Admin or Project Manager  
+# US-012 - Edit Project
+
+## Metadata
+
+- Area: 3. Projects
+- GitHub labels: `user-story`, `mvp`, `area:projects`
+- Suggested status: `Ready`
+- Suggested wave: `Wave 2`
+- Depends on: `US-009`, `US-011`
+- Parallelization note: This slice should follow `US-011` because it builds directly on the new project detail route and read contract.
+
+## User Story
+
+**As an** Admin or Project Manager  
 **I want** to edit project details  
 **So that** project information stays current.
 
-### Acceptance Criteria
+## Acceptance Criteria
 
 **Given** I am an Admin or Project Manager  
 **When** I update editable project fields  
@@ -10,44 +23,56 @@
 
 **Given** I am a Team Member  
 **When** I attempt to edit project details  
-**Then** the system denies permission.  ## Implementation Breakdown **Kanban lane:** Backlog â†’ Ready â†’ Red â†’ Green â†’ Refactor â†’ Review / QA â†’ Done  
-**Definition of Done:** All listed layer tasks are complete, reviewed, tested, and traceable to the story acceptance criteria.
+**Then** the system denies permission.
 
-### Database
-- [ ] Create/maintain project schema with UUID, owner, immutable code, task counter, dates, and soft delete.
-- [ ] Add unique/index constraints for project code and owner lookups.
+## Execution Breakdown
 
-### Backend/API
-- [ ] Implement project endpoints with pagination and permission checks.
-- [ ] Enforce immutable project code on PATCH.
-- [ ] Validate project date ranges.
-- [ ] Soft-delete project, tasks, subtasks, memberships, dependencies visibility with confirmation flag.
-- [ ] Write project activity logs.
+### Backend Slice
 
-### Frontend/UI
-- [ ] Build project create/edit/detail/list UI.
-- [ ] Prevent code editing after creation in the UI.
-- [ ] Show destructive delete confirmation text exactly as specified.
+- [x] Implement `PATCH /api/projects/{project_id}` in the owning `projects` module.
+- [x] Allow updates only to:
+  - `name`
+  - `description`
+  - `start_date`
+  - `end_date`
+- [x] Reuse active-project visibility for target lookup.
+- [x] Allow edit permission only to:
+  - Admin
+  - active `PROJECT_MANAGER` members on that project
+- [x] Deny Team Members with a structured permission error.
+- [x] Reuse project date-range validation on update.
+- [x] Return the updated canonical project payload on success.
 
-### TDD â€” Red: Write Failing Tests First
-- [ ] Map each Given/When/Then acceptance criterion to automated tests.
-- [ ] Add happy-path tests before implementation.
-- [ ] Add validation, permission, and edge-case tests before implementation.
-- [ ] Run the tests and confirm they fail for the expected reason.
-- [ ] Unit test immutable code, date validation, and soft-delete behavior.
-- [ ] Integration test project CRUD and deleted-project exclusion from normal views.
+### Frontend Slice
 
-### TDD â€” Green: Implement Minimum Passing Code
-- [ ] Implement only the smallest database/backend/frontend change needed to pass the failing tests.
-- [ ] Run the story-level test set and confirm all new tests pass.
-- [ ] Confirm existing regression tests still pass.
+- [x] Add an edit form inside the project detail workspace.
+- [x] Prefill the form from the selected project detail query.
+- [x] Submit updates through the shared API client and refresh the detail/list state.
+- [x] Surface visible success, validation, and permission-denied states.
+- [x] Keep the create flow intact and do not replace the project access workspace.
 
-### TDD â€” Refactor: Improve Safely
-- [ ] Refactor duplicated logic into services, validators, hooks, or shared components.
-- [ ] Confirm permissions, structured errors, soft-delete behavior, and edge cases remain covered.
-- [ ] Re-run unit, integration, and relevant frontend tests after refactoring.
+### Test Slice
 
-### Review / QA Checklist
-- [ ] Acceptance criteria from the user story are verified manually or by automated tests.
-- [ ] Structured API errors, permissions, and edge cases are validated where applicable.
-- [ ] Documentation or developer notes are updated if behavior is non-obvious.
+- [x] Add backend integration coverage for successful edit by Admin.
+- [x] Add backend integration coverage for successful edit by project `PROJECT_MANAGER`.
+- [x] Add backend integration coverage showing Team Members receive a permission error.
+- [x] Add backend integration coverage for invalid date-range updates.
+- [x] Add frontend integration coverage for editing a project from the detail route.
+- [x] Add frontend integration coverage for permission-denied edit attempts.
+
+## Dependencies And Notes
+
+- This slice intentionally stops at project update only. It does not implement:
+  - project deletion
+  - member management changes
+  - task flows
+  - activity-log display
+- The immutable-code invariant from `US-010` should be delivered on the same PATCH route rather than as a separate standalone branch.
+
+## Definition Of Done
+
+- `PATCH /api/projects/{project_id}` exists and updates editable project fields.
+- Admins and active project managers can edit projects.
+- Team Members cannot edit project details.
+- Invalid date ranges return a structured validation error.
+- The project detail workspace includes a working edit form with visible success and failure states.

--- a/skills/context/handoffs/2026-05-01-current-repo-state.md
+++ b/skills/context/handoffs/2026-05-01-current-repo-state.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-- The auth, admin-user, and first project read stack is now landed locally through `US-011`.
+- The auth and first project CRUD-read-update stack is now landed locally through `US-012`, with the `US-010` immutable-code invariant delivered on the same branch.
 - Current stacked branch and PR chain:
   - `us-001-auth-foundation` -> PR `#79`
   - `us-002-forced-first-login-password-reset` -> PR `#80`
@@ -13,9 +13,10 @@
   - `us-007-reset-user-password` -> PR `#85`
   - `us-008-deactivate-user` -> PR `#86`
   - `us-009-create-project` -> PR `#87`
-  - `us-011-view-project` -> PR pending
-- Current working branch is `us-011-view-project`.
-- GitHub issue states in this stack are `:owner-review` for `#6` through `#14`, with `US-011` in implementation.
+  - `us-011-view-project` -> PR `#91`
+  - `us-012-edit-project` -> PR pending
+- Current working branch is `us-012-edit-project`.
+- GitHub issue states in this stack are `:owner-review` for `#6`, `#7`, `#8`, `#9`, `#10`, `#11`, `#12`, `#13`, `#14`, and `#16`, with `US-010` and `US-012` in implementation.
 - Known unrelated local changes still present and intentionally untouched:
   - modified `.gitignore`
   - modified `AGENTS.md`
@@ -24,26 +25,29 @@
 
 ## Next Recommended Step
 
-- Start `US-012 Edit Project` from the top of the current stacked branch chain now that a real project detail route exists.
-- `US-010 Immutable Project Code` can be delivered with or immediately before the update-path work because there is now a meaningful read surface and route contract for project details.
+- Start `US-013 Delete Project With Confirmation` from the top of the current stacked branch chain now that the project detail route and edit-capable workspace already exist.
 - Reuse the current project conventions:
   - `POST /api/projects` for create
   - `GET /api/projects` for the authenticated visible-project list
   - `GET /api/projects/{project_id}` for visible-project detail reads
-  - Admin sees all active projects; members see only active memberships
+  - `PATCH /api/projects/{project_id}` for editable project fields only
+  - project `code` is immutable on PATCH and must return `PROJECT_CODE_IMMUTABLE`
 
 ## Risks Or Open Questions
 
 - PRs are intentionally stacked. Changes to an earlier base PR can require rechecking downstream branches before continuing.
 - The admin user-management surface is still backend-only. Avoid inventing frontend admin routes until a story explicitly owns that slice.
-- The project frontend surface now spans the protected-shell index route and `/projects/:projectId`. Future project stories should extend those routes instead of replacing them with another placeholder.
+- The project frontend surface now spans the protected-shell index route and `/projects/:projectId`, with detail, read-only, and edit states. Future project stories should extend those routes instead of replacing them with another placeholder.
 - `US-008` revokes live sessions on deactivation. Do not undo that behavior by moving deactivation back into a passive field update.
 - The "Project Manager can create projects" wording remains ambiguous because memberships are project-scoped. The working rule is documented in `issues/review-findings.md` and the `US-009` handoff.
-- `US-010` is best treated as an update-path invariant rather than a standalone pre-read story, even though the planning order lists it before `US-011`.
+- The current edit response includes a backend-derived `can_edit` capability flag on project detail payloads. If future actions need more than one capability, consider moving to a small `permissions` object rather than adding many top-level booleans.
 
 ## Relevant Files
 
 - `issues/stories/us-009-create-project.md`
+- `issues/stories/us-010-immutable-project-code.md`
 - `issues/stories/us-011-view-project.md`
+- `issues/stories/us-012-edit-project.md`
 - `skills/context/handoffs/2026-05-02-us-009-create-project.md`
 - `skills/context/handoffs/2026-05-02-us-011-view-project.md`
+- `skills/context/handoffs/2026-05-02-us-012-edit-project-and-us-010-immutable-project-code.md`

--- a/skills/context/handoffs/2026-05-02-us-012-edit-project-and-us-010-immutable-project-code.md
+++ b/skills/context/handoffs/2026-05-02-us-012-edit-project-and-us-010-immutable-project-code.md
@@ -1,0 +1,51 @@
+# US-012 - Edit Project and US-010 - Immutable Project Code
+
+## What Landed
+
+- Added `PATCH /api/projects/{project_id}` in the `projects` module.
+- Edit permission is now:
+  - Admin can edit any visible active project.
+  - Active `PROJECT_MANAGER` members can edit their project.
+  - Team Members receive `PROJECT_PERMISSION_DENIED`.
+- Editable fields on the PATCH route:
+  - `name`
+  - `description`
+  - `start_date`
+  - `end_date`
+- Project code is now enforced as immutable on the real update surface:
+  - any PATCH payload containing `code` returns `PROJECT_CODE_IMMUTABLE`
+  - the project row is not mutated
+
+## Frontend Outcome
+
+- The project detail workspace now includes a real edit form.
+- The edit form is prefilled from the selected project detail query and updates the shared project caches on success.
+- Project code stays visible but read-only in the edit UI.
+- Read-only project members now see a locked edit state instead of an editable form.
+
+## Tests
+
+- Backend: `tests/integration/test_projects_api.py`
+  - successful Admin edit
+  - successful Project Manager edit
+  - Team Member permission denial
+  - invalid date range rejection
+  - immutable project code rejection
+- Frontend:
+  - `src/features/projects/ProjectsFlow.test.tsx`
+  - `src/features/auth/AuthFlow.test.tsx`
+
+## Validation Snapshot
+
+- Backend: `.\.venv\Scripts\python.exe -m pytest tests\integration\test_projects_api.py` -> `17 passed`
+- Frontend: `npm run test:run -- src/features/projects/ProjectsFlow.test.tsx src/features/auth/AuthFlow.test.tsx` -> `22 passed`
+
+## Follow-On Notes
+
+- `US-013 Delete Project With Confirmation` can now build on the established project detail route and edit-capable workspace.
+- `US-010` is satisfied by this branch and should be reviewed together with `US-012`, because the invariant only became meaningful once the PATCH route existed.
+- Keep the unrelated dirty files out of feature commits:
+  - `.gitignore`
+  - `AGENTS.md`
+  - `issues/sync-policy.md`
+  - the untracked migration rename files under `backend/apps/memberships/migrations/` and `backend/apps/projects/migrations/`


### PR DESCRIPTION
## Summary
- add backend project PATCH support with admin or active project-manager permissions
- enforce `PROJECT_CODE_IMMUTABLE` on the real update surface and keep code read-only in the UI
- add a real project edit workspace with success, validation, and read-only states

## Validation
- `D:\GitHub\project-management-system\backend\.venv\Scripts\python.exe -m pytest tests\integration\test_projects_api.py` -> `17 passed`
- `npm run test:run -- src/features/projects/ProjectsFlow.test.tsx src/features/auth/AuthFlow.test.tsx` -> `22 passed`
