### PR TITLE
Implement US-013 delete project with confirmation

### DIFF
--- a/backend/apps/projects/api/serializers.py
+++ b/backend/apps/projects/api/serializers.py
@@ -19,6 +19,16 @@ class UpdateProjectSerializer(serializers.Serializer):
     end_date = serializers.DateField(required=False, allow_null=True)
 
 
+class DeleteProjectSerializer(serializers.Serializer):
+    confirm_project_delete = serializers.BooleanField(required=True)
+
+    def validate_confirm_project_delete(self, value):
+        if value is not True:
+            raise serializers.ValidationError("Project deletion confirmation is required.")
+
+        return value
+
+
 class ProjectSerializer(serializers.Serializer):
     id = serializers.UUIDField(format="hex_verbose")
     name = serializers.CharField()
@@ -32,6 +42,7 @@ class ProjectSerializer(serializers.Serializer):
 
 class ProjectDetailSerializer(ProjectSerializer):
     can_edit = serializers.SerializerMethodField()
+    can_delete = serializers.SerializerMethodField()
 
     def get_can_edit(self, obj):
         user = self.context["user"]
@@ -40,3 +51,6 @@ class ProjectDetailSerializer(ProjectSerializer):
             role=ProjectMembershipRole.PROJECT_MANAGER,
             deleted_at__isnull=True,
         ).exists()
+
+    def get_can_delete(self, obj):
+        return self.get_can_edit(obj)

--- a/backend/apps/projects/api/views.py
+++ b/backend/apps/projects/api/views.py
@@ -6,6 +6,7 @@ from rest_framework.views import APIView
 
 from apps.projects.domain.services import (
     create_project,
+    delete_project,
     DuplicateProjectCodeError,
     get_project_for_actor,
     InvalidProjectDateRangeError,
@@ -13,12 +14,14 @@ from apps.projects.domain.services import (
     ProjectNotFoundError,
     ProjectCodeImmutableError,
     ProjectCreatePermissionDeniedError,
+    ProjectDeletePermissionDeniedError,
     ProjectEditPermissionDeniedError,
     update_project,
 )
 
 from .serializers import (
     CreateProjectSerializer,
+    DeleteProjectSerializer,
     ProjectDetailSerializer,
     ProjectSerializer,
     UpdateProjectSerializer,
@@ -160,3 +163,35 @@ class ProjectDetailView(APIView):
             {"project": ProjectDetailSerializer(project, context={"user": request.user}).data},
             status=status.HTTP_200_OK,
         )
+
+    def delete(self, request, project_id):
+        serializer = DeleteProjectSerializer(data=request.data)
+        if not serializer.is_valid():
+            return error_response(
+                code="VALIDATION_ERROR",
+                message="Invalid input",
+                details=serializer.errors,
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            delete_project(
+                actor=request.user,
+                project_id=project_id,
+            )
+        except ProjectNotFoundError:
+            return error_response(
+                code="PROJECT_NOT_FOUND",
+                message="Project not found.",
+                details={},
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
+        except ProjectDeletePermissionDeniedError:
+            return error_response(
+                code="PROJECT_PERMISSION_DENIED",
+                message="You do not have permission to delete this project.",
+                details={},
+                status_code=status.HTTP_403_FORBIDDEN,
+            )
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/apps/projects/domain/policies.py
+++ b/backend/apps/projects/domain/policies.py
@@ -20,3 +20,7 @@ def can_edit_project(*, user, project) -> bool:
         user=user,
         role=ProjectMembershipRole.PROJECT_MANAGER,
     ).exists()
+
+
+def can_delete_project(*, user, project) -> bool:
+    return can_edit_project(user=user, project=project)

--- a/backend/apps/projects/domain/services.py
+++ b/backend/apps/projects/domain/services.py
@@ -1,10 +1,11 @@
 from django.db import transaction
+from django.utils import timezone
 
 from apps.memberships.models import ProjectMembership, ProjectMembershipRole
 from apps.projects.models import Project
 from apps.projects.selectors import visible_projects_for_user
 
-from .policies import can_create_project, can_edit_project
+from .policies import can_create_project, can_delete_project, can_edit_project
 
 
 class ProjectCreatePermissionDeniedError(Exception):
@@ -30,6 +31,10 @@ class ProjectEditPermissionDeniedError(Exception):
 
 
 class ProjectCodeImmutableError(Exception):
+    pass
+
+
+class ProjectDeletePermissionDeniedError(Exception):
     pass
 
 
@@ -88,6 +93,25 @@ def update_project(
     )
 
     return project
+
+
+@transaction.atomic
+def delete_project(*, actor, project_id):
+    project = get_project_for_actor(actor=actor, project_id=project_id)
+
+    if not can_delete_project(user=actor, project=project):
+        raise ProjectDeletePermissionDeniedError
+
+    deleted_at = timezone.now()
+    ProjectMembership.all_objects.filter(
+        project=project,
+        deleted_at__isnull=True,
+    ).update(
+        deleted_at=deleted_at,
+        updated_at=deleted_at,
+    )
+    project.deleted_at = deleted_at
+    project.save(update_fields=["deleted_at", "updated_at"])
 
 
 @transaction.atomic

--- a/backend/tests/integration/test_projects_api.py
+++ b/backend/tests/integration/test_projects_api.py
@@ -384,6 +384,7 @@ def test_active_project_member_can_view_project_details():
             "start_date": None,
             "end_date": None,
             "can_edit": False,
+            "can_delete": False,
         }
     }
 
@@ -476,6 +477,7 @@ def test_admin_can_edit_project_details():
             "start_date": "2026-05-03",
             "end_date": "2026-06-03",
             "can_edit": True,
+            "can_delete": True,
         }
     }
     assert project.name == "Updated Project Name"
@@ -511,6 +513,7 @@ def test_project_manager_can_edit_project_details():
     assert response.status_code == 200
     assert response.json()["project"]["name"] == "Managed Project Updated"
     assert response.json()["project"]["can_edit"] is True
+    assert response.json()["project"]["can_delete"] is True
     assert project.name == "Managed Project Updated"
 
 
@@ -613,3 +616,169 @@ def test_project_update_rejects_project_code_changes():
         }
     }
     assert project.code == "IMM"
+
+
+def test_project_delete_requires_confirmation():
+    admin_user = create_user(
+        email="project-delete-confirm-admin@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    project = create_project(owner=admin_user, code="DEL", name="Delete Me")
+    client = APIClient()
+    client.force_login(admin_user)
+
+    response = client.delete(
+        f"/api/projects/{project.id}",
+        {},
+        format="json",
+    )
+
+    project.refresh_from_db()
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": {
+            "code": "VALIDATION_ERROR",
+            "message": "Invalid input",
+            "details": {
+                "confirm_project_delete": ["This field is required."],
+            },
+        }
+    }
+    assert project.deleted_at is None
+
+
+def test_admin_can_soft_delete_a_project_and_its_memberships():
+    admin_user = create_user(
+        email="project-delete-admin@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    member_user = create_user(email="project-delete-member@example.com")
+    project = create_project(owner=admin_user, code="DELADM", name="Delete Admin Project")
+    membership = create_membership(
+        project=project,
+        user=member_user,
+        role=ProjectMembershipRole.TEAM_MEMBER,
+    )
+    owner_membership = create_membership(
+        project=project,
+        user=admin_user,
+        role=ProjectMembershipRole.PROJECT_MANAGER,
+    )
+    client = APIClient()
+    client.force_login(admin_user)
+
+    response = client.delete(
+        f"/api/projects/{project.id}",
+        {"confirm_project_delete": True},
+        format="json",
+    )
+
+    project.refresh_from_db()
+    membership.refresh_from_db()
+    owner_membership.refresh_from_db()
+
+    assert response.status_code == 204
+    assert project.deleted_at is not None
+    assert membership.deleted_at is not None
+    assert owner_membership.deleted_at is not None
+    assert client.get("/api/projects").json() == {"projects": []}
+    detail_response = client.get(f"/api/projects/{project.id}")
+    assert detail_response.status_code == 404
+
+
+def test_project_manager_can_delete_their_project():
+    admin_user = create_user(
+        email="project-delete-seed-admin@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    project_manager = create_user(email="project-delete-manager@example.com")
+    project = create_project(owner=admin_user, code="PMD", name="Managed Delete")
+    create_membership(
+        project=project,
+        user=project_manager,
+        role=ProjectMembershipRole.PROJECT_MANAGER,
+    )
+    client = APIClient()
+    client.force_login(project_manager)
+
+    response = client.delete(
+        f"/api/projects/{project.id}",
+        {"confirm_project_delete": True},
+        format="json",
+    )
+
+    project.refresh_from_db()
+
+    assert response.status_code == 204
+    assert project.deleted_at is not None
+
+
+def test_team_member_cannot_delete_a_project():
+    admin_user = create_user(
+        email="project-delete-member-admin@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    team_member = create_user(email="project-delete-team-member@example.com")
+    project = create_project(owner=admin_user, code="TMD", name="Member Delete Denied")
+    create_membership(
+        project=project,
+        user=team_member,
+        role=ProjectMembershipRole.TEAM_MEMBER,
+    )
+    client = APIClient()
+    client.force_login(team_member)
+
+    response = client.delete(
+        f"/api/projects/{project.id}",
+        {"confirm_project_delete": True},
+        format="json",
+    )
+
+    project.refresh_from_db()
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "error": {
+            "code": "PROJECT_PERMISSION_DENIED",
+            "message": "You do not have permission to delete this project.",
+            "details": {},
+        }
+    }
+    assert project.deleted_at is None
+
+
+def test_deleted_projects_are_hidden_from_members_after_delete():
+    admin_user = create_user(
+        email="project-delete-hidden-admin@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    member_user = create_user(email="project-delete-hidden-member@example.com")
+    project = create_project(owner=admin_user, code="HDP", name="Hide Deleted Project")
+    create_membership(
+        project=project,
+        user=member_user,
+        role=ProjectMembershipRole.TEAM_MEMBER,
+    )
+    client = APIClient()
+    client.force_login(admin_user)
+    client.delete(
+        f"/api/projects/{project.id}",
+        {"confirm_project_delete": True},
+        format="json",
+    )
+
+    member_client = APIClient()
+    member_client.force_login(member_user)
+
+    list_response = member_client.get("/api/projects")
+    detail_response = member_client.get(f"/api/projects/{project.id}")
+
+    assert list_response.status_code == 200
+    assert list_response.json() == {"projects": []}
+    assert detail_response.status_code == 404

--- a/frontend/src/features/projects/ProjectsFlow.test.tsx
+++ b/frontend/src/features/projects/ProjectsFlow.test.tsx
@@ -67,6 +67,7 @@ describe("projects flow", () => {
             start_date: "2026-05-01",
             end_date: "2026-06-01",
             can_edit: false,
+            can_delete: false,
           },
         },
       }),
@@ -148,6 +149,7 @@ describe("projects flow", () => {
             start_date: "2026-05-01",
             end_date: "2026-06-01",
             can_edit: true,
+            can_delete: true,
           },
         },
       }),
@@ -163,6 +165,7 @@ describe("projects flow", () => {
             start_date: "2026-05-01",
             end_date: "2026-06-01",
             can_edit: true,
+            can_delete: true,
           },
         },
       }),
@@ -194,6 +197,7 @@ describe("projects flow", () => {
             start_date: "2026-05-01",
             end_date: "2026-06-01",
             can_edit: true,
+            can_delete: true,
           },
         },
       }),
@@ -322,6 +326,7 @@ describe("projects flow", () => {
             start_date: "2026-05-01",
             end_date: "2026-06-01",
             can_edit: true,
+            can_delete: true,
           },
         },
       }),
@@ -337,6 +342,7 @@ describe("projects flow", () => {
             start_date: "2026-05-04",
             end_date: "2026-06-10",
             can_edit: true,
+            can_delete: true,
           },
         },
       }),
@@ -398,6 +404,7 @@ describe("projects flow", () => {
             start_date: "2026-05-01",
             end_date: "2026-06-01",
             can_edit: false,
+            can_delete: false,
           },
         },
       }),
@@ -407,5 +414,125 @@ describe("projects flow", () => {
 
     expect(await screen.findByText(/read-only access/i)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /save changes/i })).not.toBeInTheDocument();
+  });
+
+  it("requires explicit confirmation before deleting a project", async () => {
+    mockFetchSequence([
+      jsonResponse({
+        body: {
+          id: "user-1",
+          email: "jane@example.com",
+          name: "Jane Doe",
+          is_admin: true,
+          must_reset_password: false,
+        },
+      }),
+      jsonResponse({
+        body: {
+          projects: [
+            {
+              id: "project-1",
+              name: "Engineering Platform",
+              code: "ENG",
+              description: "Internal engineering work",
+              owner_id: "user-1",
+              task_counter: 0,
+              start_date: "2026-05-01",
+              end_date: "2026-06-01",
+            },
+          ],
+        },
+      }),
+      jsonResponse({
+        body: {
+          project: {
+            id: "project-1",
+            name: "Engineering Platform",
+            code: "ENG",
+            description: "Internal engineering work",
+            owner_id: "user-1",
+            task_counter: 0,
+            start_date: "2026-05-01",
+            end_date: "2026-06-01",
+            can_edit: true,
+            can_delete: true,
+          },
+        },
+      }),
+    ]);
+
+    const user = userEvent.setup();
+    renderApp(["/projects/project-1"], { cookie: "csrftoken=test-token; path=/" });
+
+    await user.click(await screen.findByRole("button", { name: /delete project/i }));
+
+    expect(
+      await screen.findByText(/project deletion confirmation is required before continuing/i),
+    ).toBeInTheDocument();
+  });
+
+  it("deletes a project after confirmation and returns to the workspace list", async () => {
+    const fetchMock = mockFetchSequence([
+      jsonResponse({
+        body: {
+          id: "user-1",
+          email: "jane@example.com",
+          name: "Jane Doe",
+          is_admin: true,
+          must_reset_password: false,
+        },
+      }),
+      jsonResponse({
+        body: {
+          projects: [
+            {
+              id: "project-1",
+              name: "Engineering Platform",
+              code: "ENG",
+              description: "Internal engineering work",
+              owner_id: "user-1",
+              task_counter: 0,
+              start_date: "2026-05-01",
+              end_date: "2026-06-01",
+            },
+          ],
+        },
+      }),
+      jsonResponse({
+        body: {
+          project: {
+            id: "project-1",
+            name: "Engineering Platform",
+            code: "ENG",
+            description: "Internal engineering work",
+            owner_id: "user-1",
+            task_counter: 0,
+            start_date: "2026-05-01",
+            end_date: "2026-06-01",
+            can_edit: true,
+            can_delete: true,
+          },
+        },
+      }),
+      new Response(null, { status: 204 }),
+    ]);
+
+    const user = userEvent.setup();
+    renderApp(["/projects/project-1"], { cookie: "csrftoken=test-token; path=/" });
+
+    await user.click(
+      await screen.findByLabelText(
+        /i understand this will soft-delete this project and its memberships/i,
+      ),
+    );
+    await user.click(screen.getByRole("button", { name: /delete project/i }));
+
+    expect(await screen.findByText(/no accessible projects yet/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /engineering platform/i })).not.toBeInTheDocument();
+    expect(fetchMock.mock.calls[3]?.[0]).toBe("/api/projects/project-1");
+    expect(fetchMock.mock.calls[3]?.[1]?.method).toBe("DELETE");
+    expect(fetchMock.mock.calls[3]?.[1]?.body).toBe(
+      JSON.stringify({ confirm_project_delete: true }),
+    );
   });
 });

--- a/frontend/src/features/projects/api/projectsApi.ts
+++ b/frontend/src/features/projects/api/projectsApi.ts
@@ -1,5 +1,11 @@
 import { apiRequest } from "../../../api/client";
-import { type CreateProjectRequest, type Project, type ProjectDetail, type UpdateProjectRequest } from "../types";
+import {
+  type CreateProjectRequest,
+  type DeleteProjectRequest,
+  type Project,
+  type ProjectDetail,
+  type UpdateProjectRequest,
+} from "../types";
 
 
 export async function createProject(payload: CreateProjectRequest): Promise<Project> {
@@ -31,4 +37,11 @@ export async function updateProject(
   });
 
   return response.project;
+}
+
+export async function deleteProject(projectId: string, payload: DeleteProjectRequest): Promise<void> {
+  await apiRequest(`/projects/${projectId}`, {
+    body: JSON.stringify(payload),
+    method: "DELETE",
+  });
 }

--- a/frontend/src/features/projects/hooks/useDeleteProjectMutation.ts
+++ b/frontend/src/features/projects/hooks/useDeleteProjectMutation.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { deleteProject } from "../api/projectsApi";
+import { type Project } from "../types";
+import { projectQueryKey } from "./useProjectQuery";
+import { projectsQueryKey } from "./useProjectsQuery";
+
+export function useDeleteProjectMutation(projectId: string | null) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async () => {
+      if (!projectId) {
+        throw new Error("Project id is required to delete a project.");
+      }
+
+      await deleteProject(projectId, { confirm_project_delete: true });
+    },
+    onSuccess: () => {
+      if (!projectId) {
+        return;
+      }
+
+      queryClient.setQueryData<Project[] | undefined>(projectsQueryKey, (projects) =>
+        (projects ?? []).filter((project) => project.id !== projectId),
+      );
+      queryClient.removeQueries({ queryKey: projectQueryKey(projectId), exact: true });
+    },
+  });
+}

--- a/frontend/src/features/projects/pages/ProjectsHomePage.tsx
+++ b/frontend/src/features/projects/pages/ProjectsHomePage.tsx
@@ -11,6 +11,7 @@ import { StatusMessage } from "../../../components/StatusMessage";
 import { AppShellPage } from "../../auth/pages/AppShellPage";
 import { type SessionUser } from "../../auth/types";
 import { useCreateProjectMutation } from "../hooks/useCreateProjectMutation";
+import { useDeleteProjectMutation } from "../hooks/useDeleteProjectMutation";
 import { useProjectQuery } from "../hooks/useProjectQuery";
 import { useProjectsQuery } from "../hooks/useProjectsQuery";
 import { useUpdateProjectMutation } from "../hooks/useUpdateProjectMutation";
@@ -48,8 +49,12 @@ export function ProjectsHomePage({ projectId, user }: ProjectsHomePageProps) {
   const projectsQuery = useProjectsQuery();
   const projectQuery = useProjectQuery(projectId);
   const updateProjectMutation = useUpdateProjectMutation(projectId);
+  const deleteProjectMutation = useDeleteProjectMutation(projectId);
   const [lastCreatedProjectId, setLastCreatedProjectId] = useState<string | null>(null);
   const [showEditSuccess, setShowEditSuccess] = useState(false);
+  const [deleteConfirmationChecked, setDeleteConfirmationChecked] = useState(false);
+  const [deleteConfirmationError, setDeleteConfirmationError] = useState<string | null>(null);
+  const [showDeleteSuccess, setShowDeleteSuccess] = useState(false);
   const {
     formState: { errors },
     handleSubmit,
@@ -87,6 +92,9 @@ export function ProjectsHomePage({ projectId, user }: ProjectsHomePageProps) {
     : null;
   const updateProjectError = isApiError(updateProjectMutation.error)
     ? updateProjectMutation.error
+    : null;
+  const deleteProjectError = isApiError(deleteProjectMutation.error)
+    ? deleteProjectMutation.error
     : null;
   const serverNameError = getDetailMessages(projectError?.details.name)[0];
   const serverCodeError = getDetailMessages(projectError?.details.code)[0];
@@ -126,6 +134,15 @@ export function ProjectsHomePage({ projectId, user }: ProjectsHomePageProps) {
         !serverEditCodeError
       ? updateProjectError.message
       : null;
+  const serverDeleteConfirmationError = getDetailMessages(
+    deleteProjectError?.details.confirm_project_delete,
+  )[0];
+  const serverDeleteFormError =
+    deleteProjectError &&
+    !serverDeleteConfirmationError &&
+    deleteProjectError.code !== "PROJECT_PERMISSION_DENIED"
+      ? deleteProjectError.message
+      : null;
 
   useEffect(() => {
     if (!projectQuery.data) {
@@ -145,6 +162,13 @@ export function ProjectsHomePage({ projectId, user }: ProjectsHomePageProps) {
       end_date: projectQuery.data.end_date ?? "",
     });
   }, [projectQuery.data, resetEditForm]);
+
+  useEffect(() => {
+    setDeleteConfirmationChecked(false);
+    setDeleteConfirmationError(null);
+    setShowDeleteSuccess(false);
+    deleteProjectMutation.reset();
+  }, [projectId]);
 
   return (
     <AppShellPage user={user}>
@@ -348,6 +372,98 @@ export function ProjectsHomePage({ projectId, user }: ProjectsHomePageProps) {
               ) : null}
               <Button disabled={updateProjectMutation.isPending} type="submit">
                 {updateProjectMutation.isPending ? "Saving changes..." : "Save changes"}
+              </Button>
+            </form>
+          ) : null}
+        </Panel>
+
+        <Panel className="project-delete-panel">
+          <div className="panel-heading">
+            <h2 className="panel-heading__title">Delete project</h2>
+            <p className="panel-heading__body">
+              Remove this project from the active workspace only after an explicit confirmation step.
+            </p>
+          </div>
+          {!projectQuery.data ? (
+            <StatusMessage title="Project delete is unavailable">
+              Select a project detail route before deleting.
+            </StatusMessage>
+          ) : null}
+          {projectQuery.data && !projectQuery.data.can_delete ? (
+            <StatusMessage tone="warning" title="Delete is restricted">
+              Only Admins and active Project Managers can delete this project.
+            </StatusMessage>
+          ) : null}
+          {projectQuery.data?.can_delete ? (
+            <form
+              className="form-stack"
+              onSubmit={(event) => {
+                event.preventDefault();
+                setShowDeleteSuccess(false);
+                deleteProjectMutation.reset();
+
+                if (!deleteConfirmationChecked) {
+                  setDeleteConfirmationError(
+                    "Project deletion confirmation is required before continuing.",
+                  );
+                  return;
+                }
+
+                setDeleteConfirmationError(null);
+                deleteProjectMutation.mutate(undefined, {
+                  onSuccess: () => {
+                    setShowDeleteSuccess(true);
+                    navigate("/");
+                  },
+                });
+              }}
+            >
+              <StatusMessage tone="warning" title="Destructive action">
+                Deleting a project removes it from the active workspace and also soft-deletes its memberships.
+              </StatusMessage>
+              <label className="checkbox-field" htmlFor="confirm-project-delete">
+                <input
+                  checked={deleteConfirmationChecked}
+                  className="checkbox-field__input"
+                  id="confirm-project-delete"
+                  onChange={(event) => {
+                    setDeleteConfirmationChecked(event.target.checked);
+                    if (event.target.checked) {
+                      setDeleteConfirmationError(null);
+                    }
+                  }}
+                  type="checkbox"
+                />
+                <span className="checkbox-field__label">
+                  I understand this will soft-delete this project and its memberships.
+                </span>
+              </label>
+              {deleteConfirmationError || serverDeleteConfirmationError ? (
+                <span className="field__error" role="alert">
+                  {deleteConfirmationError ?? serverDeleteConfirmationError}
+                </span>
+              ) : null}
+              {deleteProjectError?.code === "PROJECT_PERMISSION_DENIED" ? (
+                <StatusMessage tone="error" title="Permission denied">
+                  {deleteProjectError.message}
+                </StatusMessage>
+              ) : null}
+              {serverDeleteFormError ? (
+                <StatusMessage tone="error" title="Project delete failed">
+                  {serverDeleteFormError}
+                </StatusMessage>
+              ) : null}
+              {showDeleteSuccess ? (
+                <StatusMessage title="Project deleted">
+                  The project was removed from the active workspace.
+                </StatusMessage>
+              ) : null}
+              <Button
+                className="button button--danger"
+                disabled={deleteProjectMutation.isPending}
+                type="submit"
+              >
+                {deleteProjectMutation.isPending ? "Deleting project..." : "Delete project"}
               </Button>
             </form>
           ) : null}

--- a/frontend/src/features/projects/types.ts
+++ b/frontend/src/features/projects/types.ts
@@ -11,6 +11,7 @@ export type Project = {
 
 export type ProjectDetail = Project & {
   can_edit: boolean;
+  can_delete: boolean;
 };
 
 export type CreateProjectRequest = {
@@ -27,4 +28,8 @@ export type UpdateProjectRequest = {
   description?: string | null;
   start_date?: string | null;
   end_date?: string | null;
+};
+
+export type DeleteProjectRequest = {
+  confirm_project_delete: boolean;
 };

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -217,6 +217,23 @@ textarea {
   font-size: 0.9rem;
 }
 
+.checkbox-field {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--space-3);
+  align-items: start;
+}
+
+.checkbox-field__input {
+  margin-top: 0.2rem;
+  inline-size: 1.05rem;
+  block-size: 1.05rem;
+}
+
+.checkbox-field__label {
+  line-height: 1.5;
+}
+
 .button {
   display: inline-flex;
   align-items: center;
@@ -248,6 +265,11 @@ textarea {
 
 .button--secondary {
   background: var(--color-bg-ink);
+}
+
+.button--danger {
+  background: #b33a2f;
+  box-shadow: 0 12px 30px rgba(179, 58, 47, 0.24);
 }
 
 .button--full {
@@ -463,6 +485,10 @@ textarea {
   min-width: 0;
 }
 
+.project-delete-panel {
+  min-width: 0;
+}
+
 @media (min-width: 860px) {
   .screen__content {
     grid-template-columns: minmax(0, 1.3fr) minmax(22rem, 0.9fr);
@@ -489,6 +515,10 @@ textarea {
   }
 
   .project-edit-panel {
+    grid-column: 1 / -1;
+  }
+
+  .project-delete-panel {
     grid-column: 1 / -1;
   }
 

--- a/issues/review-findings.md
+++ b/issues/review-findings.md
@@ -34,6 +34,8 @@
 
 1. `US-009 Create Project` says “Admin or Project Manager” can create a project, but the approved data model only defines a global Admin and project-scoped memberships. A project-scoped role cannot exist before a project exists, so there is no fully explicit spec path for “first project manager creates a project” without prior membership state. Working implementation for `US-009` uses: Admins may always create projects, and non-admin users may create projects only if they already hold at least one active `PROJECT_MANAGER` membership on another project.
 
+2. `US-013 Delete Project With Confirmation` depends on task, subtask, and activity-log preservation rules in the spec, but those modules are not implemented in the current branch stack yet. The working slice for `US-013` is: implement project and membership soft-delete now, keep the spec confirmation flag, hide deleted projects from normal reads, and defer deeper cascades to the future task and activity-log stories.
+
 ## What Was Added
 
 1. A local `issues` folder with one story file per user story.

--- a/issues/stories/us-013-delete-project-with-confirmation.md
+++ b/issues/stories/us-013-delete-project-with-confirmation.md
@@ -1,61 +1,82 @@
-﻿# US-013 - Delete Project With Confirmation  ## Metadata - Area: 3. Projects - GitHub labels: `user-story`, `mvp`, `area:projects` - Suggested status: `Backlog` - Suggested wave: `Wave 2` - Depends on: US-009, US-011 - Parallelization note: Start once dependencies are done; run in parallel with other stories in the same wave that do not share blocking dependencies.  ## User Story **As an** Admin or Project Manager  
+# US-013 - Delete Project With Confirmation
+
+## Metadata
+
+- Area: 3. Projects
+- GitHub labels: `user-story`, `mvp`, `area:projects`
+- Suggested status: `Owner Review`
+- Suggested wave: `Wave 2`
+- Depends on: `US-009`, `US-011`
+- Reviewable slice: backend project delete contract, frontend confirmation flow, and project visibility regression coverage
+
+## User Story
+
+**As an** Admin or Project Manager  
 **I want** to delete a project only after confirmation  
 **So that** accidental project deletion is prevented.
 
-### Acceptance Criteria
+## Acceptance Criteria
 
 **Given** I have permission to delete a project  
-**When** I submit a delete request without confirmation  
-**Then** the system rejects the request.
+**When** I submit `DELETE /api/projects/{project_id}` without `confirm_project_delete = true`  
+**Then** the system rejects the request with a structured validation error.
 
 **Given** I confirm project deletion  
-**When** I delete the project  
-**Then** the system soft-deletes the project, tasks, subtasks, and memberships.
+**When** I delete a project  
+**Then** the system soft-deletes the project and its project memberships.
 
 **Given** a project is soft-deleted  
-**When** normal users search or browse projects and tasks  
-**Then** the deleted project and related work are hidden.
+**When** normal users browse project lists or project detail routes  
+**Then** the deleted project is hidden from normal project APIs and the frontend workspace.
 
 **Given** a project is deleted  
-**When** activity logs are viewed through admin/debug tooling  
-**Then** historical activity remains preserved.  ## Implementation Breakdown **Kanban lane:** Backlog â†’ Ready â†’ Red â†’ Green â†’ Refactor â†’ Review / QA â†’ Done  
-**Definition of Done:** All listed layer tasks are complete, reviewed, tested, and traceable to the story acceptance criteria.
+**When** later task, subtask, and activity-log modules are implemented  
+**Then** they must follow the global project-deletion rule from the spec and preserve historical activity instead of hard deleting it.
 
-### Database
-- [ ] Create/maintain project schema with UUID, owner, immutable code, task counter, dates, and soft delete.
-- [ ] Add unique/index constraints for project code and owner lookups.
+## Delivery Notes
 
-### Backend/API
-- [ ] Implement project endpoints with pagination and permission checks.
-- [ ] Enforce immutable project code on PATCH.
-- [ ] Validate project date ranges.
-- [ ] Soft-delete project, tasks, subtasks, memberships, dependencies visibility with confirmation flag.
-- [ ] Write project activity logs.
+- Use the API confirmation flag already defined in `docs/planning/project_spec_v4-1.md`:
+  - `confirm_project_delete: true`
+- Frontend confirmation for this slice is a required checkbox with the exact label:
+  - `I understand this will soft-delete this project and its memberships.`
+- Permission for delete matches the current edit permission boundary:
+  - Admins
+  - active `PROJECT_MANAGER` memberships on the target project
+- This slice does not invent task, subtask, or activity-log deletion code because those modules are not implemented yet in the current branch stack.
 
-### Frontend/UI
-- [ ] Build project create/edit/detail/list UI.
-- [ ] Prevent code editing after creation in the UI.
-- [ ] Show destructive delete confirmation text exactly as specified.
+## Tasks
 
-### TDD â€” Red: Write Failing Tests First
-- [ ] Map each Given/When/Then acceptance criterion to automated tests.
-- [ ] Add happy-path tests before implementation.
-- [ ] Add validation, permission, and edge-case tests before implementation.
-- [ ] Run the tests and confirm they fail for the expected reason.
-- [ ] Unit test immutable code, date validation, and soft-delete behavior.
-- [ ] Integration test project CRUD and deleted-project exclusion from normal views.
+### Backend
 
-### TDD â€” Green: Implement Minimum Passing Code
-- [ ] Implement only the smallest database/backend/frontend change needed to pass the failing tests.
-- [ ] Run the story-level test set and confirm all new tests pass.
-- [ ] Confirm existing regression tests still pass.
+- [x] Add `DELETE /api/projects/{project_id}`.
+- [x] Require `confirm_project_delete = true`.
+- [x] Soft-delete the project and all active memberships in one transaction.
+- [x] Return not found for already deleted or inaccessible projects.
+- [x] Return permission denied for visible but non-deletable members.
 
-### TDD â€” Refactor: Improve Safely
-- [ ] Refactor duplicated logic into services, validators, hooks, or shared components.
-- [ ] Confirm permissions, structured errors, soft-delete behavior, and edge cases remain covered.
-- [ ] Re-run unit, integration, and relevant frontend tests after refactoring.
+### Frontend
 
-### Review / QA Checklist
-- [ ] Acceptance criteria from the user story are verified manually or by automated tests.
-- [ ] Structured API errors, permissions, and edge cases are validated where applicable.
-- [ ] Documentation or developer notes are updated if behavior is non-obvious.
+- [x] Add a destructive delete panel on project detail routes.
+- [x] Require the confirmation checkbox before submit.
+- [x] Submit the delete request and navigate back to the project workspace root on success.
+- [x] Remove the deleted project from cached list/detail state.
+- [x] Show structured backend validation or permission errors.
+
+### Tests
+
+- [x] Backend integration coverage for confirmation required, admin delete, project-manager delete, member denial, and hidden deleted projects.
+- [x] Frontend flow coverage for checkbox-required submit, successful delete navigation, and deleted project disappearance from the workspace.
+
+## Definition Of Done
+
+- `DELETE /api/projects/{project_id}` exists and follows the confirmation contract.
+- Deleted projects no longer appear in normal list/detail reads.
+- Deleted project memberships are soft-deleted with the project.
+- The frontend exposes a visible delete flow from the project workspace.
+- Backend and frontend tests cover the acceptance criteria for this slice.
+
+## Out Of Scope
+
+- Cascading task or subtask deletion behavior
+- Activity-log write or admin/debug activity-log views
+- Membership management CRUD beyond project-delete cascade

--- a/skills/context/handoffs/2026-05-01-current-repo-state.md
+++ b/skills/context/handoffs/2026-05-01-current-repo-state.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-- The auth and first project CRUD-read-update stack is now landed locally through `US-012`, with the `US-010` immutable-code invariant delivered on the same branch.
+- The auth and first project CRUD-delete stack is now landed locally through `US-013`, with the `US-010` immutable-code invariant delivered alongside the edit slice.
 - Current stacked branch and PR chain:
   - `us-001-auth-foundation` -> PR `#79`
   - `us-002-forced-first-login-password-reset` -> PR `#80`
@@ -14,23 +14,26 @@
   - `us-008-deactivate-user` -> PR `#86`
   - `us-009-create-project` -> PR `#87`
   - `us-011-view-project` -> PR `#91`
-  - `us-012-edit-project` -> PR pending
-- Current working branch is `us-012-edit-project`.
-- GitHub issue states in this stack are `:owner-review` for `#6`, `#7`, `#8`, `#9`, `#10`, `#11`, `#12`, `#13`, `#14`, and `#16`, with `US-010` and `US-012` in implementation.
+  - `us-012-edit-project` -> PR `#92`
+  - `us-013-delete-project` -> PR pending
+- Current working branch is `us-013-delete-project`.
+- GitHub issue states in this stack are `:owner-review` for `#6`, `#7`, `#8`, `#9`, `#10`, `#11`, `#12`, `#13`, `#14`, `#15`, `#16`, and `#17`, with `US-013` implemented locally and waiting for issue sync.
 - Known unrelated local changes still present and intentionally untouched:
   - modified `.gitignore`
   - modified `AGENTS.md`
   - modified `issues/sync-policy.md`
+  - modified skill files under `skills/`
   - untracked migration rename files under `backend/apps/memberships/migrations/` and `backend/apps/projects/migrations/`
 
 ## Next Recommended Step
 
-- Start `US-013 Delete Project With Confirmation` from the top of the current stacked branch chain now that the project detail route and edit-capable workspace already exist.
+- Start `US-014 Add Project Member` from the top of the current stacked branch chain now that the project detail route has create, view, edit, and delete coverage.
 - Reuse the current project conventions:
   - `POST /api/projects` for create
   - `GET /api/projects` for the authenticated visible-project list
   - `GET /api/projects/{project_id}` for visible-project detail reads
   - `PATCH /api/projects/{project_id}` for editable project fields only
+  - `DELETE /api/projects/{project_id}` with `confirm_project_delete: true`
   - project `code` is immutable on PATCH and must return `PROJECT_CODE_IMMUTABLE`
 
 ## Risks Or Open Questions
@@ -41,6 +44,7 @@
 - `US-008` revokes live sessions on deactivation. Do not undo that behavior by moving deactivation back into a passive field update.
 - The "Project Manager can create projects" wording remains ambiguous because memberships are project-scoped. The working rule is documented in `issues/review-findings.md` and the `US-009` handoff.
 - The current edit response includes a backend-derived `can_edit` capability flag on project detail payloads. If future actions need more than one capability, consider moving to a small `permissions` object rather than adding many top-level booleans.
+- The current project detail response now includes both `can_edit` and `can_delete`. Membership stories can keep using those for the existing workspace until a richer permissions object becomes worth introducing.
 
 ## Relevant Files
 
@@ -48,6 +52,8 @@
 - `issues/stories/us-010-immutable-project-code.md`
 - `issues/stories/us-011-view-project.md`
 - `issues/stories/us-012-edit-project.md`
+- `issues/stories/us-013-delete-project-with-confirmation.md`
 - `skills/context/handoffs/2026-05-02-us-009-create-project.md`
 - `skills/context/handoffs/2026-05-02-us-011-view-project.md`
 - `skills/context/handoffs/2026-05-02-us-012-edit-project-and-us-010-immutable-project-code.md`
+- `skills/context/handoffs/2026-05-02-us-013-delete-project.md`

--- a/skills/context/handoffs/2026-05-02-us-013-delete-project.md
+++ b/skills/context/handoffs/2026-05-02-us-013-delete-project.md
@@ -1,0 +1,27 @@
+# US-013 - Delete Project With Confirmation
+
+## Delivered Slice
+
+- Added `DELETE /api/projects/{project_id}` with the spec confirmation flag `confirm_project_delete: true`.
+- Soft-delete currently cascades through:
+  - the project row
+  - active project memberships on that project
+- Deleted projects now disappear from normal project list and detail reads because the existing active managers/selectors already exclude soft-deleted projects.
+- Frontend project detail now includes a real destructive delete panel with the exact confirmation copy:
+  - `I understand this will soft-delete this project and its memberships.`
+
+## Important Boundaries
+
+- The spec also mentions task, subtask, and activity-log preservation, but those modules are not implemented in the current branch stack yet.
+- `US-013` intentionally stops at project and membership soft-delete and records the deeper cascade as a deferred dependency in `issues/review-findings.md`.
+
+## Validation
+
+- Backend: `22 passed`
+  - `pytest tests/integration/test_projects_api.py`
+- Frontend: `24 passed`
+  - `npm run test:run -- src/features/projects/ProjectsFlow.test.tsx src/features/auth/AuthFlow.test.tsx`
+
+## Next Useful Step
+
+- Continue with `US-014 Add Project Member`, which can now assume the project workspace has create, view, edit, and delete behavior in place.


### PR DESCRIPTION
## Summary
- add `DELETE /api/projects/{project_id}` with required `confirm_project_delete: true`
- soft-delete projects and project memberships, and hide deleted projects from normal reads
- add a real frontend delete flow with explicit confirmation, cache eviction, and workspace redirect

## Validation
- `pytest tests/integration/test_projects_api.py` -> `22 passed`
- `npm run test:run -- src/features/projects/ProjectsFlow.test.tsx src/features/auth/AuthFlow.test.tsx` -> `24 passed`

## Notes
- This slice intentionally stops at project and membership soft-delete.
- Task, subtask, and activity-log cascade behavior is deferred because those modules are not implemented in the current branch stack yet.