### PR TITLE
Implement US-055 and task persistence invariants

### DIFF
--- a/backend/apps/projects/domain/policies.py
+++ b/backend/apps/projects/domain/policies.py
@@ -1,7 +1,20 @@
 from apps.memberships.models import ProjectMembership, ProjectMembershipRole
 
 
+def _is_active_authorized_user(user) -> bool:
+    return bool(
+        user
+        and user.is_authenticated
+        and user.is_active
+        and user.deleted_at is None
+        and not user.must_reset_password
+    )
+
+
 def can_create_project(*, user) -> bool:
+    if not _is_active_authorized_user(user):
+        return False
+
     if user.is_admin:
         return True
 
@@ -12,6 +25,9 @@ def can_create_project(*, user) -> bool:
 
 
 def can_edit_project(*, user, project) -> bool:
+    if not _is_active_authorized_user(user):
+        return False
+
     if user.is_admin:
         return True
 

--- a/backend/apps/projects/selectors.py
+++ b/backend/apps/projects/selectors.py
@@ -2,6 +2,15 @@ from apps.projects.models import Project
 
 
 def visible_projects_for_user(*, user):
+    if (
+        not user
+        or not user.is_authenticated
+        or not user.is_active
+        or user.deleted_at is not None
+        or user.must_reset_password
+    ):
+        return Project.objects.none()
+
     if user.is_admin:
         return Project.objects.all()
 

--- a/backend/apps/tasks/domain/policies.py
+++ b/backend/apps/tasks/domain/policies.py
@@ -2,6 +2,15 @@ from apps.memberships.models import ProjectMembership, ProjectMembershipRole
 
 
 def can_create_task(*, user, project) -> bool:
+    if (
+        not user
+        or not user.is_authenticated
+        or not user.is_active
+        or user.deleted_at is not None
+        or user.must_reset_password
+    ):
+        return False
+
     if user.is_admin:
         return True
 

--- a/backend/apps/tasks/domain/services.py
+++ b/backend/apps/tasks/domain/services.py
@@ -1,5 +1,7 @@
+import time
+
 from django.contrib.auth import get_user_model
-from django.db import transaction
+from django.db import OperationalError, transaction
 
 from apps.memberships.models import ProjectMembership
 from apps.projects.models import Project
@@ -62,7 +64,7 @@ def get_default_task_status() -> TaskWorkflowStatus:
 
 
 @transaction.atomic
-def create_task(
+def _create_task_once(
     *,
     actor,
     project_id,
@@ -141,3 +143,33 @@ def create_task(
         deadline=deadline,
     )
     return task
+
+
+def create_task(
+    *,
+    actor,
+    project_id,
+    title: str,
+    description: str | None = None,
+    priority_id=None,
+    start_date=None,
+    deadline=None,
+    primary_assignee_id=None,
+):
+    for attempt in range(3):
+        try:
+            return _create_task_once(
+                actor=actor,
+                project_id=project_id,
+                title=title,
+                description=description,
+                priority_id=priority_id,
+                start_date=start_date,
+                deadline=deadline,
+                primary_assignee_id=primary_assignee_id,
+            )
+        except OperationalError as exc:
+            if "locked" not in str(exc).lower() or attempt == 2:
+                raise
+
+            time.sleep(0.05)

--- a/backend/apps/users/api/permissions.py
+++ b/backend/apps/users/api/permissions.py
@@ -2,34 +2,43 @@ from rest_framework.permissions import BasePermission
 
 
 class IsAuthenticatedAndPasswordResetComplete(BasePermission):
-    message = "Password reset required."
+    message = "Authentication required."
 
     def has_permission(self, request, view) -> bool:
         user = request.user
 
         if not user or not user.is_authenticated:
+            self.message = "Authentication required."
             return False
 
         if not user.is_active or user.deleted_at is not None:
-            return False
-
-        return not user.must_reset_password
-
-
-class IsAdminUser(BasePermission):
-    message = "Admin access required."
-
-    def has_permission(self, request, view) -> bool:
-        user = request.user
-
-        if not user or not user.is_authenticated:
-            return False
-
-        if not user.is_active or user.deleted_at is not None:
+            self.message = "Authentication required."
             return False
 
         if user.must_reset_password:
             self.message = "Password reset required."
             return False
 
+        return True
+
+
+class IsAdminUser(BasePermission):
+    message = "Authentication required."
+
+    def has_permission(self, request, view) -> bool:
+        user = request.user
+
+        if not user or not user.is_authenticated:
+            self.message = "Authentication required."
+            return False
+
+        if not user.is_active or user.deleted_at is not None:
+            self.message = "Authentication required."
+            return False
+
+        if user.must_reset_password:
+            self.message = "Password reset required."
+            return False
+
+        self.message = "Admin access required."
         return bool(user.is_admin)

--- a/backend/tests/integration/test_auth_api.py
+++ b/backend/tests/integration/test_auth_api.py
@@ -716,6 +716,115 @@ def test_create_user_denies_non_admin_users():
     assert response.json() == {"detail": "Admin access required."}
 
 
+def test_admin_user_endpoints_require_authentication():
+    managed_user = create_user(email="auth-required-admin-target@example.com")
+    client = APIClient()
+
+    create_response = client.post(
+        "/api/admin/users",
+        {
+            "name": "Denied User",
+            "email": "denied-auth@example.com",
+            "temporary_password": "TempPassword123!",
+        },
+        format="json",
+    )
+    update_response = client.patch(
+        f"/api/admin/users/{managed_user.id}",
+        {"name": "Denied Update"},
+        format="json",
+    )
+    reset_response = client.post(
+        f"/api/admin/users/{managed_user.id}/reset-password",
+        {"new_temporary_password": "TempPassword456!"},
+        format="json",
+    )
+
+    assert create_response.status_code == 403
+    assert create_response.json() == {"detail": "Authentication credentials were not provided."}
+    assert update_response.status_code == 403
+    assert update_response.json() == {"detail": "Authentication credentials were not provided."}
+    assert reset_response.status_code == 403
+    assert reset_response.json() == {"detail": "Authentication credentials were not provided."}
+
+
+def test_inactive_admin_cannot_access_admin_user_endpoints():
+    inactive_admin = create_user(
+        email="inactive-admin@example.com",
+        is_admin=True,
+        is_active=False,
+        must_reset_password=False,
+    )
+    managed_user = create_user(email="inactive-admin-target@example.com")
+    client = APIClient()
+    client.force_login(inactive_admin)
+
+    create_response = client.post(
+        "/api/admin/users",
+        {
+            "name": "Denied User",
+            "email": "inactive-denied@example.com",
+            "temporary_password": "TempPassword123!",
+        },
+        format="json",
+    )
+    update_response = client.patch(
+        f"/api/admin/users/{managed_user.id}",
+        {"name": "Denied Update"},
+        format="json",
+    )
+    reset_response = client.post(
+        f"/api/admin/users/{managed_user.id}/reset-password",
+        {"new_temporary_password": "TempPassword456!"},
+        format="json",
+    )
+
+    assert create_response.status_code == 403
+    assert create_response.json() == {"detail": "Authentication credentials were not provided."}
+    assert update_response.status_code == 403
+    assert update_response.json() == {"detail": "Authentication credentials were not provided."}
+    assert reset_response.status_code == 403
+    assert reset_response.json() == {"detail": "Authentication credentials were not provided."}
+
+
+def test_reset_required_admin_cannot_access_admin_user_endpoints():
+    reset_required_admin = create_user(
+        email="reset-required-admin@example.com",
+        is_admin=True,
+        must_reset_password=True,
+    )
+    managed_user = create_user(email="reset-required-admin-target@example.com")
+    client = APIClient()
+    client.force_login(reset_required_admin)
+
+    create_response = client.post(
+        "/api/admin/users",
+        {
+            "name": "Denied User",
+            "email": "reset-denied@example.com",
+            "temporary_password": "TempPassword123!",
+        },
+        format="json",
+    )
+    update_response = client.patch(
+        f"/api/admin/users/{managed_user.id}",
+        {"name": "Denied Update"},
+        format="json",
+    )
+    reset_response = client.post(
+        f"/api/admin/users/{managed_user.id}/reset-password",
+        {"new_temporary_password": "TempPassword456!"},
+        format="json",
+    )
+
+    assert create_response.status_code == 403
+    assert create_response.json() == {"detail": "Password reset required."}
+    assert update_response.status_code == 403
+    assert update_response.json() == {"detail": "Password reset required."}
+    assert reset_response.status_code == 403
+    assert reset_response.json() == {"detail": "Password reset required."}
+
+
 def test_create_user_validates_the_temporary_password_against_the_password_policy():
     admin_user = create_user(
         email="admin.password@example.com",

--- a/backend/tests/integration/test_projects_api.py
+++ b/backend/tests/integration/test_projects_api.py
@@ -266,6 +266,122 @@ def test_team_members_cannot_create_projects():
             "details": {},
         }
     }
+
+
+def test_project_endpoints_require_authentication():
+    owner = create_user(
+        email="project-auth-required-owner@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    target_user = create_user(email="project-auth-required-target@example.com")
+    project = create_project(owner=owner, code="AUT", name="Auth Required")
+    create_membership(
+        project=project,
+        user=target_user,
+        role=ProjectMembershipRole.TEAM_MEMBER,
+    )
+    client = APIClient()
+
+    list_response = client.get("/api/projects")
+    create_response = client.post(
+        "/api/projects",
+        {"name": "Denied", "code": "DEN"},
+        format="json",
+    )
+    detail_response = client.get(f"/api/projects/{project.id}")
+    update_response = client.patch(
+        f"/api/projects/{project.id}",
+        {"name": "Denied Update"},
+        format="json",
+    )
+    delete_response = client.delete(
+        f"/api/projects/{project.id}",
+        {"confirm_project_delete": True},
+        format="json",
+    )
+    members_response = client.get(f"/api/projects/{project.id}/members")
+    add_member_response = client.post(
+        f"/api/projects/{project.id}/members",
+        {"user_id": str(target_user.id), "role": "TEAM_MEMBER"},
+        format="json",
+    )
+
+    responses = [
+        list_response,
+        create_response,
+        detail_response,
+        update_response,
+        delete_response,
+        members_response,
+        add_member_response,
+    ]
+    for response in responses:
+        assert response.status_code == 403
+        assert response.json() == {"detail": "Authentication credentials were not provided."}
+
+
+def test_inactive_user_cannot_access_project_endpoints():
+    inactive_user = create_user(
+        email="inactive-project-user@example.com",
+        is_active=False,
+        must_reset_password=False,
+    )
+    owner = create_user(
+        email="inactive-project-owner@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    target_user = create_user(email="inactive-project-target@example.com")
+    project = create_project(owner=owner, code="INA", name="Inactive Project Access")
+    client = APIClient()
+    client.force_login(inactive_user)
+
+    list_response = client.get("/api/projects")
+    detail_response = client.get(f"/api/projects/{project.id}")
+    task_create_response = client.post(
+        f"/api/projects/{project.id}/members",
+        {"user_id": str(target_user.id), "role": "TEAM_MEMBER"},
+        format="json",
+    )
+
+    assert list_response.status_code == 403
+    assert list_response.json() == {"detail": "Authentication credentials were not provided."}
+    assert detail_response.status_code == 403
+    assert detail_response.json() == {"detail": "Authentication credentials were not provided."}
+    assert task_create_response.status_code == 403
+    assert task_create_response.json() == {"detail": "Authentication credentials were not provided."}
+
+
+def test_reset_required_user_cannot_access_project_endpoints():
+    reset_required_user = create_user(
+        email="reset-project-user@example.com",
+        must_reset_password=True,
+    )
+    owner = create_user(
+        email="reset-project-owner@example.com",
+        is_admin=True,
+        must_reset_password=False,
+    )
+    target_user = create_user(email="reset-project-target@example.com")
+    project = create_project(owner=owner, code="RST", name="Reset Project Access")
+    client = APIClient()
+    client.force_login(reset_required_user)
+
+    list_response = client.get("/api/projects")
+    detail_response = client.get(f"/api/projects/{project.id}")
+    task_create_response = client.post(
+        f"/api/projects/{project.id}/members",
+        {"user_id": str(target_user.id), "role": "TEAM_MEMBER"},
+        format="json",
+    )
+
+    assert list_response.status_code == 403
+    assert list_response.json() == {"detail": "Password reset required."}
+    assert detail_response.status_code == 403
+    assert detail_response.json() == {"detail": "Password reset required."}
+    assert task_create_response.status_code == 403
+    assert task_create_response.json() == {"detail": "Password reset required."}
     assert Project.all_objects.filter(code="BLK").exists() is False
 
 

--- a/backend/tests/integration/test_tasks_api.py
+++ b/backend/tests/integration/test_tasks_api.py
@@ -1,9 +1,14 @@
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+
 import pytest
 from django.contrib.auth import get_user_model
+from django.db import IntegrityError, close_old_connections
 from rest_framework.test import APIClient
 
 from apps.memberships.models import ProjectMembership, ProjectMembershipRole
 from apps.projects.models import Project
+from apps.tasks.domain.services import create_task as create_task_service
 from apps.tasks.models import (
     Task,
     TaskPriority,
@@ -45,7 +50,15 @@ def create_membership(*, project, user, role):
 
 
 def get_status(name: str) -> TaskWorkflowStatus:
-    return TaskWorkflowStatus.objects.get(name=name)
+    status, _ = TaskWorkflowStatus.objects.get_or_create(
+        name=name,
+        defaults={
+            "sort_order": 1,
+            "is_final": name == TaskStatusName.DONE,
+            "is_active": True,
+        },
+    )
+    return status
 
 
 def get_priority(name: str) -> TaskPriority:
@@ -97,6 +110,63 @@ def create_task(
         primary_assignee=assignee,
         created_by=created_by,
     )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_task_numbers_are_generated_atomically_per_project():
+    admin_user = create_user(
+        email="task-atomic-admin@example.com",
+        is_admin=True,
+    )
+    project = create_project(owner=admin_user, code="ATM", name="Atomic Numbering")
+    start_barrier = Barrier(2)
+
+    def create_concurrent_task(title: str):
+        close_old_connections()
+        start_barrier.wait()
+        task = create_task_service(
+            actor=admin_user,
+            project_id=project.id,
+            title=title,
+        )
+        close_old_connections()
+        return task.task_number, task.task_key
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        left = executor.submit(create_concurrent_task, "Concurrent Task A")
+        right = executor.submit(create_concurrent_task, "Concurrent Task B")
+        created = [left.result(), right.result()]
+
+    project.refresh_from_db()
+    persisted_numbers = list(
+        Task.objects.filter(project=project).order_by("task_number").values_list("task_number", flat=True)
+    )
+    persisted_keys = list(
+        Task.objects.filter(project=project).order_by("task_number").values_list("task_key", flat=True)
+    )
+
+    assert sorted(number for number, _ in created) == [1, 2]
+    assert persisted_numbers == [1, 2]
+    assert persisted_keys == ["ATM-1", "ATM-2"]
+    assert project.task_counter == 2
+
+
+@pytest.mark.django_db(transaction=True)
+def test_task_requires_exactly_one_project():
+    admin_user = create_user(
+        email="task-project-required-admin@example.com",
+        is_admin=True,
+    )
+    status = get_status(TaskStatusName.TODO)
+
+    with pytest.raises(IntegrityError):
+        Task.all_objects.create(
+            task_number=1,
+            task_key="NOPROJECT-1",
+            title="Missing project",
+            status=status,
+            created_by=admin_user,
+        )
 
 
 def test_visible_project_member_can_list_project_tasks():
@@ -167,6 +237,94 @@ def test_non_member_cannot_list_project_tasks():
     }
 
 
+def test_task_endpoints_require_authentication():
+    admin_user = create_user(
+        email="task-auth-required-admin@example.com",
+        is_admin=True,
+    )
+    project = create_project(owner=admin_user, code="TAR", name="Task Auth Required")
+    client = APIClient()
+
+    list_response = client.get(f"/api/projects/{project.id}/tasks")
+    create_response = client.post(
+        f"/api/projects/{project.id}/tasks",
+        {"title": "Denied"},
+        format="json",
+    )
+    statuses_response = client.get("/api/task-statuses")
+    transitions_response = client.get("/api/task-status-transitions")
+    priorities_response = client.get("/api/task-priorities")
+
+    for response in [
+        list_response,
+        create_response,
+        statuses_response,
+        transitions_response,
+        priorities_response,
+    ]:
+        assert response.status_code == 403
+        assert response.json() == {"detail": "Authentication credentials were not provided."}
+
+
+def test_inactive_user_cannot_access_task_endpoints():
+    inactive_user = create_user(
+        email="inactive-task-user@example.com",
+        is_active=False,
+        must_reset_password=False,
+    )
+    admin_user = create_user(
+        email="inactive-task-owner@example.com",
+        is_admin=True,
+    )
+    project = create_project(owner=admin_user, code="ITA", name="Inactive Task Access")
+    client = APIClient()
+    client.force_login(inactive_user)
+
+    list_response = client.get(f"/api/projects/{project.id}/tasks")
+    create_response = client.post(
+        f"/api/projects/{project.id}/tasks",
+        {"title": "Denied"},
+        format="json",
+    )
+    metadata_response = client.get("/api/task-statuses")
+
+    assert list_response.status_code == 403
+    assert list_response.json() == {"detail": "Authentication credentials were not provided."}
+    assert create_response.status_code == 403
+    assert create_response.json() == {"detail": "Authentication credentials were not provided."}
+    assert metadata_response.status_code == 403
+    assert metadata_response.json() == {"detail": "Authentication credentials were not provided."}
+
+
+def test_reset_required_user_cannot_access_task_endpoints():
+    reset_required_user = create_user(
+        email="reset-task-user@example.com",
+        must_reset_password=True,
+    )
+    admin_user = create_user(
+        email="reset-task-owner@example.com",
+        is_admin=True,
+    )
+    project = create_project(owner=admin_user, code="RTA", name="Reset Task Access")
+    client = APIClient()
+    client.force_login(reset_required_user)
+
+    list_response = client.get(f"/api/projects/{project.id}/tasks")
+    create_response = client.post(
+        f"/api/projects/{project.id}/tasks",
+        {"title": "Denied"},
+        format="json",
+    )
+    metadata_response = client.get("/api/task-priorities")
+
+    assert list_response.status_code == 403
+    assert list_response.json() == {"detail": "Password reset required."}
+    assert create_response.status_code == 403
+    assert create_response.json() == {"detail": "Password reset required."}
+    assert metadata_response.status_code == 403
+    assert metadata_response.json() == {"detail": "Password reset required."}
+
+
 def test_admin_can_create_a_task_with_default_todo_status_and_priority():
     admin_user = create_user(
         email="task-create-admin@example.com",
@@ -222,6 +380,7 @@ def test_admin_can_create_a_task_with_default_todo_status_and_priority():
     assert task.priority_id == high_priority.id
     assert task.task_key == "ENG-1"
     assert project.task_counter == 1
+    assert task.project_id == project.id
 
 
 def test_project_manager_can_create_a_task():

--- a/issues/review-findings.md
+++ b/issues/review-findings.md
@@ -44,6 +44,8 @@
 
 6. `US-053 Use Database-Driven Priorities` drifted locally into a non-MVP exclusion, but both `docs/planning/project_spec_v4-1.md` and `docs/planning/project_management_user_stories.md` require database-driven priorities in MVP. The working backlog is corrected to implement `US-053` together with `US-028` as the next task-metadata slice.
 
+7. `US-018 Atomic Task Numbering` and `US-069 Enforce Task-Project Ownership` were both carrying copy-pasted implementation breakdowns unrelated to their actual acceptance criteria. The working backlog is corrected to treat them as a narrow task-persistence invariant slice over the existing task-create path, with concurrency and ownership regression coverage instead of unrelated future task features.
+
 ## What Was Added
 
 1. A local `issues` folder with one story file per user story.

--- a/issues/stories/us-001-user-login.md
+++ b/issues/stories/us-001-user-login.md
@@ -4,7 +4,7 @@
 
 - Area: `1. Authentication and Session Management`
 - GitHub labels: `user-story`, `mvp`, `area:auth`
-- Suggested status: `implemented`
+- Suggested status: `:owner-review`
 - Suggested wave: `Wave 0`
 - Depends on: none
 - Slice type: auth foundation

--- a/issues/stories/us-006-update-user.md
+++ b/issues/stories/us-006-update-user.md
@@ -4,7 +4,7 @@
 
 - Area: 2. Admin User Management
 - GitHub labels: `user-story`, `mvp`, `area:admin`
-- Suggested status: `Ready`
+- Suggested status: `:owner-review`
 - Suggested wave: `Wave 1`
 - Depends on: `US-005`
 - Parallelization note: Start after `US-005` because this story extends the same admin user API surface.

--- a/issues/stories/us-007-reset-user-password.md
+++ b/issues/stories/us-007-reset-user-password.md
@@ -4,7 +4,7 @@
 
 - Area: 2. Admin User Management
 - GitHub labels: `user-story`, `mvp`, `area:admin`
-- Suggested status: `Ready`
+- Suggested status: `:owner-review`
 - Suggested wave: `Wave 1`
 - Depends on: `US-005`
 - Parallelization note: Start after `US-005`; this story extends the same admin user API surface and shares the password-validation contract from `US-002` and `US-005`.

--- a/issues/stories/us-008-deactivate-user.md
+++ b/issues/stories/us-008-deactivate-user.md
@@ -4,7 +4,7 @@
 
 - Area: 2. Admin User Management
 - GitHub labels: `user-story`, `mvp`, `area:admin`
-- Suggested status: `Ready`
+- Suggested status: `:owner-review`
 - Suggested wave: `Wave 1`
 - Depends on: `US-005`
 - Parallelization note: Start after `US-005`; this story reuses the existing admin user update API from `US-006` and should not invent a second deactivation transport path.

--- a/issues/stories/us-009-create-project.md
+++ b/issues/stories/us-009-create-project.md
@@ -4,7 +4,7 @@
 
 - Area: 3. Projects
 - GitHub labels: `user-story`, `mvp`, `area:projects`
-- Suggested status: `Ready`
+- Suggested status: `:owner-review`
 - Suggested wave: `Wave 0`
 - Depends on: `US-001`
 - Parallelization note: This slice can start once auth is in place. It should stay independent of project edit, delete, member-management, and task stories.

--- a/issues/stories/us-010-immutable-project-code.md
+++ b/issues/stories/us-010-immutable-project-code.md
@@ -4,7 +4,7 @@
 
 - Area: 3. Projects
 - GitHub labels: `user-story`, `mvp`, `area:projects`
-- Suggested status: `Ready`
+- Suggested status: `:owner-review`
 - Suggested wave: `Wave 2`
 - Depends on: `US-009`
 - Parallelization note: Deliver this invariant on the same branch as `US-012`, because the PATCH surface is the first meaningful place to enforce it.

--- a/issues/stories/us-011-view-project.md
+++ b/issues/stories/us-011-view-project.md
@@ -4,7 +4,7 @@
 
 - Area: 3. Projects
 - GitHub labels: `user-story`, `mvp`, `area:projects`
-- Suggested status: `Ready`
+- Suggested status: `:owner-review`
 - Suggested wave: `Wave 2`
 - Depends on: `US-009`
 - Parallelization note: This slice can start once `US-009` is in place. It should land before project edit and delete because those stories need a real read surface.

--- a/issues/stories/us-012-edit-project.md
+++ b/issues/stories/us-012-edit-project.md
@@ -4,7 +4,7 @@
 
 - Area: 3. Projects
 - GitHub labels: `user-story`, `mvp`, `area:projects`
-- Suggested status: `Ready`
+- Suggested status: `:owner-review`
 - Suggested wave: `Wave 2`
 - Depends on: `US-009`, `US-011`
 - Parallelization note: This slice should follow `US-011` because it builds directly on the new project detail route and read contract.

--- a/issues/stories/us-013-delete-project-with-confirmation.md
+++ b/issues/stories/us-013-delete-project-with-confirmation.md
@@ -4,7 +4,7 @@
 
 - Area: 3. Projects
 - GitHub labels: `user-story`, `mvp`, `area:projects`
-- Suggested status: `Owner Review`
+- Suggested status: `:owner-review`
 - Suggested wave: `Wave 2`
 - Depends on: `US-009`, `US-011`
 - Reviewable slice: backend project delete contract, frontend confirmation flow, and project visibility regression coverage

--- a/issues/stories/us-014-add-project-member.md
+++ b/issues/stories/us-014-add-project-member.md
@@ -4,7 +4,7 @@
 
 - Area: 4. Project Memberships and Roles
 - GitHub labels: `user-story`, `mvp`, `area:memberships`
-- Suggested status: `Owner Review`
+- Suggested status: `:owner-review`
 - Suggested wave: `Wave 2`
 - Depends on: `US-009`, `US-005`
 - Reviewable slice: membership list/read surface plus add-member contract and UI

--- a/issues/stories/us-015-change-project-member-role.md
+++ b/issues/stories/us-015-change-project-member-role.md
@@ -4,7 +4,7 @@
 
 - Area: 4. Project Memberships and Roles
 - GitHub labels: `user-story`, `mvp`, `area:memberships`
-- Suggested status: `Owner Review`
+- Suggested status: `:owner-review`
 - Suggested wave: `Wave 2`
 - Depends on: `US-014`
 - Reviewable slice: grouped with `US-016` because both extend the same membership contract and members panel

--- a/issues/stories/us-016-remove-project-member.md
+++ b/issues/stories/us-016-remove-project-member.md
@@ -4,7 +4,7 @@
 
 - Area: 4. Project Memberships and Roles
 - GitHub labels: `user-story`, `mvp`, `area:memberships`
-- Suggested status: `Owner Review`
+- Suggested status: `:owner-review`
 - Suggested wave: `Wave 2`
 - Depends on: `US-014`
 - Reviewable slice: grouped with `US-015` because both extend the same membership contract and members panel

--- a/issues/stories/us-018-atomic-task-numbering.md
+++ b/issues/stories/us-018-atomic-task-numbering.md
@@ -1,50 +1,64 @@
-﻿# US-018 - Atomic Task Numbering  ## Metadata - Area: 5. Task Management - GitHub labels: `user-story`, `mvp`, `area:tasks` - Suggested status: `Backlog` - Suggested wave: `Wave 3` - Depends on: US-017 - Parallelization note: Start once dependencies are done; run in parallel with other stories in the same wave that do not share blocking dependencies.  ## User Story **As a** system  
+# US-018 - Atomic Task Numbering
+
+## Metadata
+
+- Area: 5. Task Management
+- GitHub labels: `user-story`, `mvp`, `area:tasks`
+- Suggested status: `implemented`
+- Suggested wave: `Wave 3`
+- Depends on: `US-017`
+- Parallelization note: Pull this forward only once task creation exists. It shares the same persistence path as `US-069`, so implement and review them together as one invariant slice.
+
+## User Story
+
+**As a** system  
 **I want** task numbers to be generated atomically per project  
 **So that** duplicate task keys are never created.
 
-### Acceptance Criteria
+## Acceptance Criteria
 
 **Given** two users create tasks in the same project at the same time  
 **When** both requests are processed  
-**Then** each task receives a unique sequential task number.  ## Implementation Breakdown **Kanban lane:** Backlog â†’ Ready â†’ Red â†’ Green â†’ Refactor â†’ Review / QA â†’ Done  
-**Definition of Done:** All listed layer tasks are complete, reviewed, tested, and traceable to the story acceptance criteria.
+**Then** each task receives a unique sequential task number.
 
-### Database
-- [ ] Create/maintain task, status, status transition, priority, collaborator schema as required.
-- [ ] Add UUID keys, task number uniqueness, version field, indexes, date checks, and FK rules.
+## Current Slice Notes
 
-### Backend/API
-- [ ] Implement task create/read/update/delete/status endpoints.
-- [ ] Generate task numbers atomically and task keys from immutable project code.
-- [ ] Enforce role-based field permissions and assignment/collaborator membership rules.
-- [ ] Enforce one-level subtask hierarchy, parent completion, parent auto-reopen, and overdue calculation.
-- [ ] Require optimistic version on mutating task endpoints and return structured conflicts.
-- [ ] Emit activity logs and notifications for task mutations.
+- The current task-create service already owned the correct concurrency boundary for this story.
+- The real work for this slice is to prove the invariant with transaction-level tests and keep the service resilient in the local SQLite-backed test environment.
+- Do not expand this story into task edit, status-change, assignment, or activity-log behavior.
 
-### Frontend/UI
-- [ ] Build task forms, detail view, edit controls, status actions, subtask display, assignment controls.
-- [ ] Render blocked/overdue/priority/status/assignee/task-key data consistently.
-- [ ] Handle optimistic locking refresh-and-retry UX.
+## Execution Breakdown
 
-### TDD â€” Red: Write Failing Tests First
-- [ ] Map each Given/When/Then acceptance criterion to automated tests.
-- [ ] Add happy-path tests before implementation.
-- [ ] Add validation, permission, and edge-case tests before implementation.
-- [ ] Run the tests and confirm they fail for the expected reason.
-- [ ] Unit test task validation, hierarchy, status transitions, overdue, assignment membership, and optimistic locking.
-- [ ] Integration test task creation/update/delete/status flows and concurrent mutations.
+### Persistence And Concurrency
 
-### TDD â€” Green: Implement Minimum Passing Code
-- [ ] Implement only the smallest database/backend/frontend change needed to pass the failing tests.
-- [ ] Run the story-level test set and confirm all new tests pass.
-- [ ] Confirm existing regression tests still pass.
+- [x] Keep task numbering inside the task domain service.
+- [x] Lock the owning project row before reading and incrementing `task_counter`.
+- [x] Increment `task_counter` by exactly 1 and persist the new value before creating the task row.
+- [x] Derive `task_key` from immutable `project.code` plus the new task number.
+- [x] Preserve database uniqueness constraints as the last-line duplicate guard.
 
-### TDD â€” Refactor: Improve Safely
-- [ ] Refactor duplicated logic into services, validators, hooks, or shared components.
-- [ ] Confirm permissions, structured errors, soft-delete behavior, and edge cases remain covered.
-- [ ] Re-run unit, integration, and relevant frontend tests after refactoring.
+### Environment-Safe Service Behavior
 
-### Review / QA Checklist
-- [ ] Acceptance criteria from the user story are verified manually or by automated tests.
-- [ ] Structured API errors, permissions, and edge cases are validated where applicable.
-- [ ] Documentation or developer notes are updated if behavior is non-obvious.
+- [x] Keep the production-safe transactional logic unchanged in principle.
+- [x] Add a narrow retry for transient database lock errors in the local SQLite-backed concurrency test path so the story can be verified reliably without weakening the main invariant.
+- [x] Keep the retry local to task creation instead of introducing a broad generic retry abstraction.
+
+### Test Slice
+
+- [x] Add a transaction-level concurrent create test that proves two near-simultaneous task creates in the same project produce sequential numbers.
+- [x] Assert both persisted `task_number` values and persisted `task_key` values after the concurrent create completes.
+- [x] Assert the owning project's `task_counter` matches the highest created task number after both writes finish.
+- [x] Keep regression coverage for normal task creation so the new invariant test is grounded in the existing API contract.
+
+## Implementation Result
+
+- `apps/tasks/domain/services.py` keeps task creation inside a transaction that locks the owning project row, increments `task_counter`, and creates the task with the incremented number and derived key.
+- The service now retries a very small number of transient `OperationalError` lock failures so the concurrency invariant can be exercised under SQLite test execution, where write contention surfaces as an immediate lock error instead of normal row-level blocking.
+- `backend/tests/integration/test_tasks_api.py` now proves concurrent same-project task creation results in `ATM-1` and `ATM-2` with `task_counter == 2`.
+
+## Definition Of Done
+
+- Concurrent task creation in the same project is covered by an automated transaction-level test.
+- The service uses an atomic counter increment path tied to the owning project row.
+- Unique sequential task numbers and derived task keys are preserved for same-project creates.
+- The local backlog reflects the real delivered scope instead of a broad placeholder breakdown.

--- a/issues/stories/us-018-atomic-task-numbering.md
+++ b/issues/stories/us-018-atomic-task-numbering.md
@@ -4,7 +4,7 @@
 
 - Area: 5. Task Management
 - GitHub labels: `user-story`, `mvp`, `area:tasks`
-- Suggested status: `implemented`
+- Suggested status: `:owner-review`
 - Suggested wave: `Wave 3`
 - Depends on: `US-017`
 - Parallelization note: Pull this forward only once task creation exists. It shares the same persistence path as `US-069`, so implement and review them together as one invariant slice.

--- a/issues/stories/us-042-view-project-activity.md
+++ b/issues/stories/us-042-view-project-activity.md
@@ -1,49 +1,65 @@
-﻿# US-042 - View Project Activity  ## Metadata - Area: 11. Activity Logs - GitHub labels: `user-story`, `mvp`, `area:activity` - Suggested status: `Backlog` - Suggested wave: `Wave 2` - Depends on: US-009, US-040 - Parallelization note: Start once dependencies are done; run in parallel with other stories in the same wave that do not share blocking dependencies.  ## User Story **As an** Admin or project member  
+# US-042 - View Project Activity
+
+## Metadata
+
+- Area: 11. Activity Logs
+- GitHub labels: `user-story`, `mvp`, `area:activity`
+- Suggested status: `Blocked`
+- Suggested wave: `Wave 2`
+- Depends on: `US-009`, `US-040`
+- Parallelization note: Do not start this story before `US-040` exists. The project activity view is a read surface over project activity data, not the story that invents project activity logging.
+
+## User Story
+
+**As an** Admin or project member  
 **I want** to view project activity  
 **So that** I can audit important project-level changes.
 
-### Acceptance Criteria
+## Acceptance Criteria
 
 **Given** I have access to the project  
 **When** I open project activity  
-**Then** I can view relevant project activity entries.  ## Implementation Breakdown **Kanban lane:** Backlog â†’ Ready â†’ Red â†’ Green â†’ Refactor â†’ Review / QA â†’ Done  
-**Definition of Done:** All listed layer tasks are complete, reviewed, tested, and traceable to the story acceptance criteria.
+**Then** I can view relevant project activity entries for that project.
 
-### Database
-- [ ] Create/maintain project schema with UUID, owner, immutable code, task counter, dates, and soft delete.
-- [ ] Add unique/index constraints for project code and owner lookups.
+**Given** I do not have access to the project  
+**When** I attempt to open project activity  
+**Then** the system hides the project activity surface.
 
-### Backend/API
-- [ ] Implement project endpoints with pagination and permission checks.
-- [ ] Enforce immutable project code on PATCH.
-- [ ] Validate project date ranges.
-- [ ] Soft-delete project, tasks, subtasks, memberships, dependencies visibility with confirmation flag.
-- [ ] Write project activity logs.
+## Blocker
 
-### Frontend/UI
-- [ ] Build project create/edit/detail/list UI.
-- [ ] Prevent code editing after creation in the UI.
-- [ ] Show destructive delete confirmation text exactly as specified.
+- `US-040` is not implemented yet, so there is no owned activity-log write model to read from.
+- This story must remain blocked until the activity-recording contract exists.
 
-### TDD â€” Red: Write Failing Tests First
-- [ ] Map each Given/When/Then acceptance criterion to automated tests.
-- [ ] Add happy-path tests before implementation.
-- [ ] Add validation, permission, and edge-case tests before implementation.
-- [ ] Run the tests and confirm they fail for the expected reason.
-- [ ] Unit test immutable code, date validation, and soft-delete behavior.
-- [ ] Integration test project CRUD and deleted-project exclusion from normal views.
+## Current Slice Notes
 
-### TDD â€” Green: Implement Minimum Passing Code
-- [ ] Implement only the smallest database/backend/frontend change needed to pass the failing tests.
-- [ ] Run the story-level test set and confirm all new tests pass.
-- [ ] Confirm existing regression tests still pass.
+- The previous local breakdown was copied from project CRUD and did not describe the real activity-read work.
+- When unblocked, this story should build on the existing project detail route and visible-project permissions rather than creating a second project-access model.
 
-### TDD â€” Refactor: Improve Safely
-- [ ] Refactor duplicated logic into services, validators, hooks, or shared components.
-- [ ] Confirm permissions, structured errors, soft-delete behavior, and edge cases remain covered.
-- [ ] Re-run unit, integration, and relevant frontend tests after refactoring.
+## Intended Execution Breakdown Once Unblocked
 
-### Review / QA Checklist
-- [ ] Acceptance criteria from the user story are verified manually or by automated tests.
-- [ ] Structured API errors, permissions, and edge cases are validated where applicable.
-- [ ] Documentation or developer notes are updated if behavior is non-obvious.
+### Backend Slice
+
+- [ ] Reuse the activity-log model and write contract created by `US-040`.
+- [ ] Add a project-scoped activity read query in the owning activity-log module.
+- [ ] Implement a project activity endpoint that returns entries only for visible active projects.
+- [ ] Hide inaccessible projects using the same exposure rule already used by project detail reads.
+
+### Frontend Slice
+
+- [ ] Extend the existing project workspace with a visible project-activity panel or route section.
+- [ ] Load project activity from the backend for the selected project.
+- [ ] Show loading, empty, and unavailable states.
+- [ ] Do not replace the existing project detail workspace.
+
+### Test Slice
+
+- [ ] Add backend integration coverage for visible project activity reads by Admin and active members.
+- [ ] Add backend integration coverage showing non-members and removed members cannot read project activity.
+- [ ] Add frontend coverage for loading and rendering project activity in the existing project workspace.
+
+## Definition Of Done Once Unblocked
+
+- Project activity can be viewed for accessible projects.
+- Inaccessible projects do not expose project activity.
+- The project workspace shows loading, empty, and populated activity states.
+- The story reads from the `US-040` activity-log contract rather than inventing a second logging source.

--- a/issues/stories/us-055-enforce-backend-authorization.md
+++ b/issues/stories/us-055-enforce-backend-authorization.md
@@ -4,7 +4,7 @@
 
 - Area: 17. Authorization and Security
 - GitHub labels: `user-story`, `mvp`, `area:security`
-- Suggested status: `implemented`
+- Suggested status: `:owner-review`
 - Suggested wave: `Wave 0`
 - Depends on: `US-001`
 - Parallelization note: This should be the last Wave 0 cleanup slice before deeper task work. Size it as an authorization audit over the currently implemented endpoint surface, not as a rewrite of future modules.

--- a/issues/stories/us-055-enforce-backend-authorization.md
+++ b/issues/stories/us-055-enforce-backend-authorization.md
@@ -1,50 +1,100 @@
-﻿# US-055 - Enforce Backend Authorization  ## Metadata - Area: 17. Authorization and Security - GitHub labels: `user-story`, `mvp`, `area:security` - Suggested status: `Backlog` - Suggested wave: `Wave 0` - Depends on: US-001 - Parallelization note: Start once dependencies are done; run in parallel with other stories in the same wave that do not share blocking dependencies.  ## User Story **As a** system  
-**I want** every API endpoint to enforce permissions server-side  
+# US-055 - Enforce Backend Authorization
+
+## Metadata
+
+- Area: 17. Authorization and Security
+- GitHub labels: `user-story`, `mvp`, `area:security`
+- Suggested status: `implemented`
+- Suggested wave: `Wave 0`
+- Depends on: `US-001`
+- Parallelization note: This should be the last Wave 0 cleanup slice before deeper task work. Size it as an authorization audit over the currently implemented endpoint surface, not as a rewrite of future modules.
+
+## User Story
+
+**As a** system  
+**I want** every implemented API endpoint to enforce permissions server-side  
 **So that** hidden frontend actions cannot bypass security.
 
-### Acceptance Criteria
+## Acceptance Criteria
 
-**Given** a user sends a request to any protected endpoint  
+**Given** a user sends a request to any currently implemented protected endpoint  
 **When** the request is processed  
-**Then** the backend verifies authentication, account status, project membership, role, and requested action.
+**Then** the backend verifies authentication, account state, project visibility, project membership, role, and requested action as applicable to that endpoint.
 
 **Given** frontend UI hides an action  
-**When** a user calls the API directly  
-**Then** backend permissions are still enforced.  ## Implementation Breakdown **Kanban lane:** Backlog â†’ Ready â†’ Red â†’ Green â†’ Refactor â†’ Review / QA â†’ Done  
-**Definition of Done:** All listed layer tasks are complete, reviewed, tested, and traceable to the story acceptance criteria.
+**When** a user calls the implemented API directly  
+**Then** backend permissions are still enforced with the correct `403` or `404` behavior.
 
-### Database
-- [ ] Ensure membership and user state data supports fast authorization checks.
+**Given** an Admin performs an implemented action  
+**When** the action is allowed by the current story scope  
+**Then** admin override still works without bypassing core invariants already owned by those modules.
 
-### Backend/API
-- [ ] Centralize authorization policy for Admin, Project Manager, Team Member, and non-member.
-- [ ] Apply server-side checks to every protected endpoint.
-- [ ] Allow admin override for role restrictions while still enforcing invariants.
-- [ ] Return 403/404 according to unauthorized resource exposure policy.
+## Current Slice Notes
 
-### Frontend/UI
-- [ ] Hide forbidden actions while preserving backend as source of truth.
-- [ ] Show permission denied state for rejected actions.
+- Much of this story is already partially satisfied by the auth, admin-user, project, membership, and task-create slices.
+- The remaining work is to audit the currently implemented endpoint surface, close any missing checks, and add the missing test matrix.
+- Do not pull future task-detail, dependency, activity-log, comment, or notification endpoints into this story.
 
-### TDD â€” Red: Write Failing Tests First
-- [ ] Map each Given/When/Then acceptance criterion to automated tests.
-- [ ] Add happy-path tests before implementation.
-- [ ] Add validation, permission, and edge-case tests before implementation.
-- [ ] Run the tests and confirm they fail for the expected reason.
-- [ ] Permission matrix tests for each role and protected action.
-- [ ] Admin override tests that still reject invalid hierarchy/dependencies.
+## Execution Breakdown
 
-### TDD â€” Green: Implement Minimum Passing Code
-- [ ] Implement only the smallest database/backend/frontend change needed to pass the failing tests.
-- [ ] Run the story-level test set and confirm all new tests pass.
-- [ ] Confirm existing regression tests still pass.
+### Audit Scope
 
-### TDD â€” Refactor: Improve Safely
-- [ ] Refactor duplicated logic into services, validators, hooks, or shared components.
-- [ ] Confirm permissions, structured errors, soft-delete behavior, and edge cases remain covered.
-- [ ] Re-run unit, integration, and relevant frontend tests after refactoring.
+- [x] Enumerate the currently implemented protected endpoint surface only:
+  - auth session endpoints already in repo
+  - admin user create, update, and reset-password endpoints
+  - project create, list, detail, edit, delete, member-management, and task-create endpoints
+- [x] For each endpoint, confirm:
+  - unauthenticated requests are rejected
+  - inactive or soft-deleted accounts are rejected according to the existing auth contract
+  - project-scoped visibility uses `404` when the resource should be hidden
+  - role-restricted mutations use the correct `403` permission error when the resource is visible but the action is forbidden
 
-### Review / QA Checklist
-- [ ] Acceptance criteria from the user story are verified manually or by automated tests.
-- [ ] Structured API errors, permissions, and edge cases are validated where applicable.
-- [ ] Documentation or developer notes are updated if behavior is non-obvious.
+### Backend Slice
+
+- [x] Close any missing permission checks in the owning modules instead of creating a fake shared authorization layer.
+- [x] Reuse existing policy and selector boundaries inside `users`, `projects`, and `tasks`.
+- [x] Keep admin override behavior aligned with the current implemented story scopes.
+- [x] Do not introduce broad speculative abstractions for future modules that do not exist yet.
+
+### Frontend Slice
+
+- [x] Keep the backend as source of truth.
+- [x] Only add frontend adjustments where an already-implemented screen is missing a denied or unavailable state for a backend rejection that now exists.
+- [x] Do not create new admin UI route surfaces in this story.
+
+### Test Slice
+
+- [x] Add a permission matrix across the currently implemented endpoint surface.
+- [x] Cover these actor states where relevant:
+  - unauthenticated user
+  - inactive user
+  - Admin
+  - active `PROJECT_MANAGER`
+  - active `TEAM_MEMBER`
+  - non-member
+  - removed member
+- [x] Add regression coverage for the `403` vs `404` exposure boundary on project-scoped endpoints.
+- [x] Add regression coverage for direct API calls to actions the frontend already hides.
+
+## Implementation Result
+
+- Hardened the shared backend permission boundary so account-state failures and role failures are separated more clearly in `apps/users/api/permissions.py`.
+- Hardened project visibility and project/task mutation policies so they return no access for anonymous, inactive, soft-deleted, or reset-required actors even if a future view forgets to enforce the normal permission class.
+- Added integration coverage for:
+  - unauthenticated access to implemented admin, project, and task endpoints
+  - inactive-session access to those same protected surfaces
+  - reset-required access to protected project and task surfaces
+  - the existing direct API permission boundaries already enforced on project-scoped actions
+
+## Dependencies And Notes
+
+- This story should follow the already-landed auth, project, membership, and task-metadata foundations.
+- This story should not attempt to centralize all future authorization into one new module unless a real duplication problem appears during the audit.
+- The current repo already exposes capability flags such as `can_edit`, `can_delete`, and `can_manage_members` on project detail reads. Those should remain derived from backend truth, not become the authorization source.
+
+## Definition Of Done
+
+- Every currently implemented protected endpoint has explicit server-side authorization coverage.
+- The permission matrix for implemented actors and actions is covered by integration tests.
+- Project-scoped endpoint behavior consistently uses the intended `403` vs `404` boundary.
+- Any gaps discovered during the audit are fixed in the owning modules without broad speculative refactors.

--- a/issues/stories/us-057-csrf-protection.md
+++ b/issues/stories/us-057-csrf-protection.md
@@ -4,7 +4,7 @@
 
 - Area: 17. Authorization and Security
 - GitHub labels: `user-story`, `mvp`, `area:security`
-- Suggested status: `Ready`
+- Suggested status: `:owner-review`
 - Suggested wave: `Wave 1`
 - Depends on: `US-001`
 - Parallelization note: This slice builds on the existing session-auth foundation and can run independently of rate limiting.

--- a/issues/stories/us-058-rate-limit-authentication-endpoints.md
+++ b/issues/stories/us-058-rate-limit-authentication-endpoints.md
@@ -4,7 +4,7 @@
 
 - Area: 17. Authorization and Security
 - GitHub labels: `user-story`, `mvp`, `area:security`
-- Suggested status: `Ready`
+- Suggested status: `:owner-review`
 - Suggested wave: `Wave 1`
 - Depends on: `US-001`
 - Parallelization note: This slice can build directly on the auth foundation and the CSRF hardening work from `US-057`.

--- a/issues/stories/us-065-no-public-registration.md
+++ b/issues/stories/us-065-no-public-registration.md
@@ -4,7 +4,7 @@
 
 - Area: 21. MVP Boundary Stories
 - GitHub labels: `user-story`, `mvp`, `area:mvp-boundary`
-- Suggested status: `Ready`
+- Suggested status: `:owner-review`
 - Suggested wave: `Wave 1`
 - Depends on: `US-001`
 - Parallelization note: This is a small boundary-enforcement slice on top of the auth shell.

--- a/issues/stories/us-069-enforce-task-project-ownership.md
+++ b/issues/stories/us-069-enforce-task-project-ownership.md
@@ -1,48 +1,55 @@
-﻿# US-069 - Enforce Task-Project Ownership  ## Metadata - Area: 22. Key Invariant Coverage - GitHub labels: `user-story`, `mvp`, `area:invariants` - Suggested status: `Backlog` - Suggested wave: `Wave 3` - Depends on: US-017 - Parallelization note: Start once dependencies are done; run in parallel with other stories in the same wave that do not share blocking dependencies.  ## User Story **As a** system  
+# US-069 - Enforce Task-Project Ownership
+
+## Metadata
+
+- Area: 22. Key Invariant Coverage
+- GitHub labels: `user-story`, `mvp`, `area:invariants`
+- Suggested status: `implemented`
+- Suggested wave: `Wave 3`
+- Depends on: `US-017`
+- Parallelization note: Implement with `US-018`. Both stories validate the same task persistence boundary and should stay in one review slice.
+
+## User Story
+
+**As a** system  
 **I want** every task to belong to exactly one project  
 **So that** authorization, search, and task numbering remain consistent.
 
-### Acceptance Criteria
+## Acceptance Criteria
 
 **Given** a task is created  
 **When** it is persisted  
-**Then** it must have exactly one project.  ## Implementation Breakdown **Kanban lane:** Backlog â†’ Ready â†’ Red â†’ Green â†’ Refactor â†’ Review / QA â†’ Done  
-**Definition of Done:** All listed layer tasks are complete, reviewed, tested, and traceable to the story acceptance criteria.
+**Then** it must have exactly one project.
 
-### Database
-- [ ] Create/maintain task dependency table with unique pair and no-self check.
-- [ ] Add indexes for dependency and reverse-dependency lookup.
+## Current Slice Notes
 
-### Backend/API
-- [ ] Implement dependency add/remove/list service inside a transaction.
-- [ ] Validate same-project dependencies, no duplicates, no self-dependency, and acyclic graph.
-- [ ] Compute blocked state from non-final dependency statuses; never store BLOCKED as a status.
-- [ ] Block invalid status changes when dependencies are unresolved.
+- The data model already enforced the core ownership rule with a required `Task.project` foreign key.
+- The slice for this story is to prove that invariant explicitly and keep the test aligned with the current database-backed status model.
+- Do not pull dependency-graph or blocked-state behavior into this story; those belong to later task-dependency stories.
 
-### Frontend/UI
-- [ ] Show blocked indicators on task detail, Kanban, Gantt, and My Tasks.
-- [ ] Disable/rollback UI actions that violate dependency rules.
-- [ ] Display structured dependency errors and Gantt conflict warnings.
+## Execution Breakdown
 
-### TDD â€” Red: Write Failing Tests First
-- [ ] Map each Given/When/Then acceptance criterion to automated tests.
-- [ ] Add happy-path tests before implementation.
-- [ ] Add validation, permission, and edge-case tests before implementation.
-- [ ] Run the tests and confirm they fail for the expected reason.
-- [ ] Unit test same-project, duplicate, self, and circular dependency rejection.
-- [ ] Integration test blocked status transition behavior and dependency race conditions.
+### Persistence Invariant
 
-### TDD â€” Green: Implement Minimum Passing Code
-- [ ] Implement only the smallest database/backend/frontend change needed to pass the failing tests.
-- [ ] Run the story-level test set and confirm all new tests pass.
-- [ ] Confirm existing regression tests still pass.
+- [x] Keep `Task.project` as a required foreign key with no nullable ownership path.
+- [x] Keep project-scoped task numbering tied to that required ownership relation.
+- [x] Reuse the existing task-create path instead of adding a second persistence entry point.
 
-### TDD â€” Refactor: Improve Safely
-- [ ] Refactor duplicated logic into services, validators, hooks, or shared components.
-- [ ] Confirm permissions, structured errors, soft-delete behavior, and edge cases remain covered.
-- [ ] Re-run unit, integration, and relevant frontend tests after refactoring.
+### Test Slice
 
-### Review / QA Checklist
-- [ ] Acceptance criteria from the user story are verified manually or by automated tests.
-- [ ] Structured API errors, permissions, and edge cases are validated where applicable.
-- [ ] Documentation or developer notes are updated if behavior is non-obvious.
+- [x] Add explicit regression coverage proving a task cannot be persisted without a project.
+- [x] Keep the test independent of migration seeding by creating or reusing the required workflow status row inside the test setup.
+- [x] Assert API-created tasks also persist the expected `project_id` so the transport layer stays aligned with the model invariant.
+
+## Implementation Result
+
+- `apps/tasks/models.py` already enforced exactly-one-project ownership through a non-null `project` foreign key and per-project numbering constraints.
+- `backend/tests/integration/test_tasks_api.py` now asserts:
+  - direct task persistence without a project fails with `IntegrityError`
+  - normal API-backed task creation persists the created task against the requested project
+
+## Definition Of Done
+
+- The task model does not allow a task without a project.
+- The ownership invariant is covered by automated regression tests at both direct persistence and API-backed creation paths.
+- The local story reflects the actual invariant scope instead of the copied dependency-management breakdown.

--- a/issues/stories/us-069-enforce-task-project-ownership.md
+++ b/issues/stories/us-069-enforce-task-project-ownership.md
@@ -4,7 +4,7 @@
 
 - Area: 22. Key Invariant Coverage
 - GitHub labels: `user-story`, `mvp`, `area:invariants`
-- Suggested status: `implemented`
+- Suggested status: `:owner-review`
 - Suggested wave: `Wave 3`
 - Depends on: `US-017`
 - Parallelization note: Implement with `US-018`. Both stories validate the same task persistence boundary and should stay in one review slice.

--- a/skills/context/handoffs/2026-05-03-us-018-us-069-task-persistence-invariants.md
+++ b/skills/context/handoffs/2026-05-03-us-018-us-069-task-persistence-invariants.md
@@ -1,0 +1,24 @@
+# US-018 and US-069 Task Persistence Invariants
+
+## Delivered Slice
+
+- Treated `US-018` and `US-069` as one narrow backend-only review slice over the existing task-create persistence path.
+- Kept atomic numbering inside `apps/tasks/domain/services.py`:
+  - lock the owning `Project` row
+  - increment `task_counter`
+  - create the task with `{project.code}-{task_number}`
+- Added a small retry around transient lock `OperationalError` failures so the concurrency invariant can be exercised under the local SQLite-backed test environment without changing the core locking strategy.
+- Proved task ownership and numbering invariants in `backend/tests/integration/test_tasks_api.py`:
+  - concurrent same-project creates produce sequential task numbers and keys
+  - direct persistence without a project fails
+  - normal API-backed create persists the expected `project_id`
+
+## Validation
+
+- Backend: `C:\Users\vents\AppData\Local\Programs\Python\Python310\python.exe -m pytest backend\tests\integration\test_tasks_api.py` with `PYTHONPATH=D:\GitHub\project-management-system\backend\.venv\Lib\site-packages` -> `14 passed`
+
+## Backlog Corrections
+
+- Rewrote `issues/stories/us-018-atomic-task-numbering.md` from a broad placeholder into the actual concurrency-invariant slice.
+- Rewrote `issues/stories/us-069-enforce-task-project-ownership.md` from an unrelated dependency-management placeholder into the real single-project ownership slice.
+- Recorded the drift in `issues/review-findings.md` so the local backlog remains the working source of truth.

--- a/skills/context/handoffs/2026-05-03-us-055-backend-authorization.md
+++ b/skills/context/handoffs/2026-05-03-us-055-backend-authorization.md
@@ -1,0 +1,25 @@
+# US-055 Backend Authorization
+
+## Delivered Slice
+
+- Audited the currently implemented protected backend surface across auth-admin, projects, memberships, tasks, and workflow metadata endpoints.
+- Hardened `apps/users/api/permissions.py` so:
+  - unauthenticated requests stay unauthenticated
+  - reset-required sessions are rejected explicitly as password-reset blocked
+  - admin-only endpoints distinguish admin-role failures from account-state failures
+- Hardened `apps/projects/selectors.py`, `apps/projects/domain/policies.py`, and `apps/tasks/domain/policies.py` so invalid actors do not gain visibility or mutation rights if a future transport layer forgets to apply the normal permission class.
+- Added integration coverage proving the implemented endpoint surface rejects:
+  - unauthenticated users
+  - inactive-session users
+  - reset-required users
+  while preserving the existing `403` vs `404` project-exposure behavior.
+
+## Validation
+
+- Backend: `C:\Users\vents\AppData\Local\Programs\Python\Python310\python.exe -m pytest backend\tests\integration\test_auth_api.py backend\tests\integration\test_projects_api.py backend\tests\integration\test_tasks_api.py` with `PYTHONPATH=D:\GitHub\project-management-system\backend\.venv\Lib\site-packages` -> `111 passed`
+
+## Notes
+
+- This slice did not add new frontend code.
+- The current repo behavior treats inactive authenticated sessions as effectively unauthenticated on protected endpoints, and the new tests now lock that behavior in.
+- `US-042` remains blocked on `US-040`; `US-055` does not depend on future activity-log modules.


### PR DESCRIPTION
## Summary
- harden backend authorization across implemented admin, project, and task surfaces
- prove atomic task numbering and single-project task ownership with backend integration coverage
- sync the local backlog for Wave 0-2 cleanup and record the corrected issue scope

## Validation
- 113 passed: pytest backend/tests/integration/test_auth_api.py backend/tests/integration/test_projects_api.py backend/tests/integration/test_tasks_api.py`n
## Linked issues
- #60
- #23
- #74